### PR TITLE
Feature/#1070 remove database settings from Ampersand compiler

### DIFF
--- a/bootstrap/framework.php
+++ b/bootstrap/framework.php
@@ -80,7 +80,7 @@ $model = new Model(dirname(__FILE__, 2) . '/generics', $logger);
 
 $settings = new Settings($logger); // includes default framework settings
 $settings->set('global.absolutePath', dirname(__FILE__, 2));
-$settings->loadSettingsJsonFile($model->getFilePath('settings')); // load model settings from Ampersand generator
+$settings->loadSettingsFromCompiler($model); // load model settings from Ampersand compiler
 $settings->loadSettingsYamlFile(dirname(__FILE__, 2) . '/config/project.yaml'); // load project specific settings
 $settings->loadSettingsFromEnv();
 $debugMode = $settings->get('global.debugMode');

--- a/bootstrap/framework.php
+++ b/bootstrap/framework.php
@@ -98,7 +98,7 @@ $mysqlDB = new MysqlDB(
     $settings->get('mysql.dbHost'),
     $settings->get('mysql.dbUser'),
     $settings->get('mysql.dbPass'),
-    $settings->get('mysql.dbName'),
+    $settings->get('mysql.dbName', $settings->get('global.contextName')),
     Logger::getLogger('DATABASE'),
     $settings->get('global.debugMode'),
     $settings->get('global.productionEnv')

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased changes
+* [Issue 1070](https://github.com/AmpersandTarski/Ampersand/issues/1070) Don't pick up database configurations from Ampersand compiler anymore
 * [Issue 1096](https://github.com/AmpersandTarski/Ampersand/issues/1096) Show more usefull error message when composer autoloader file can not be found
 
 ## v1.6.1 (24 july 2020)

--- a/src/Ampersand/Misc/defaultSettings.yaml
+++ b/src/Ampersand/Misc/defaultSettings.yaml
@@ -33,11 +33,11 @@ settings:
   # compiler.version: null
   # compiler.env: null
 
-  ### Mysql settings (provided by compiler)
-  # mysql.dbHost: localhost
+  ### Mysql settings
+  mysql.dbHost: localhost
   # mysql.dbName: ampersand_myapplication
-  # mysql.dbUser: ampersand
-  # mysql.dbPass: ampersand
+  mysql.dbUser: ampersand
+  mysql.dbPass: ampersand
 
   ### RBAC (Role Based Access Control)
   # null implies that everyone has access, use empty list [] to disable for all, or specify a list with allowed roles

--- a/src/Ampersand/Misc/defaultSettings.yaml
+++ b/src/Ampersand/Misc/defaultSettings.yaml
@@ -35,7 +35,7 @@ settings:
 
   ### Mysql settings
   mysql.dbHost: localhost
-  # mysql.dbName: ampersand_myapplication
+  mysql.dbName: null # when not configured, the 'global.contextName' config is used
   mysql.dbUser: ampersand
   mysql.dbPass: ampersand
 

--- a/src/Ampersand/Plugs/MysqlDB/MysqlDB.php
+++ b/src/Ampersand/Plugs/MysqlDB/MysqlDB.php
@@ -340,6 +340,8 @@ class MysqlDB implements ConceptPlugInterface, RelationPlugInterface, IfcPlugInt
             if (!$this->productionMode) {
                 // Convert mysqli_sql_exceptions into 500 errors
                 switch ($e->getCode()) {
+                    case 1102: // Error: 1102 Incorrect database name
+                        throw new Exception("Incorrect MYSQL database name '{$this->dbName}'. Configure a database name that complies with the MariaDB identifier rules. If not configured the Ampersand CONTEXT name is used by default", 500, $e);
                     case 1146: // Error: 1146 SQLSTATE: 42S02 (ER_NO_SUCH_TABLE)
                     case 1054: // Error: 1054 SQLSTATE: 42S22 (ER_BAD_FIELD_ERROR)
                         throw new NotInstalledException("{$e->getMessage()}. Try reinstalling the application");


### PR DESCRIPTION
This PR is the prototype framework part of AmpersandTarski/Ampersand#1070

Can be merged independent of the Ampersand compiler part.

This PR implements that database settings are **not** picked up anymore from the `settings.json` file as provided by the Ampersand compiler.

The defaults are now implemented in the prototype framework:
username: ampersand
password: ampersand
host: localhost
database name: <the context name as provided by compiler>

Any of these settings can be configured as explained here: https://github.com/AmpersandTarski/prototype/tree/development/config