### PR TITLE
Don't import all of primeflex in box-form.component.scss

### DIFF
--- a/frontend/src/app/shared/box-components/box-form/box-form.component.scss
+++ b/frontend/src/app/shared/box-components/box-form/box-form.component.scss
@@ -1,5 +1,3 @@
-@import "../../../../../node_modules/primeflex/primeflex.scss";
-
 ::ng-deep .box-form-label {
-    @include styleclass('text-500');
+  color: var(--surface-500);
 }


### PR DESCRIPTION
The `@import` added all of primeflex to the output css. I don't think that's intended at this point.

This PR replaces this with equivalent css.