### PR TITLE
Fix/import show invariant violations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,10 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
 
 Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format. In our case this is e.g. `-rc.1`, `-rc.2`.
 
+## v2.0.8 (5 mei 2026)
+
+* Bugfix import: show invariant violation details instead of generic "400 Bad Request" error when population import (in the excel importer) fails due to rule violations
+
 ## v2.0.7 (7 apr 2026)
 
 * Documentation: add guide "Configuring Development and Production Environments" explaining `global.debugMode`, `global.productionEnv`, the configuration loading order, all environment variables, and a Docker Compose example for switching between environments

--- a/frontend/src/app/admin/population/import/import.component.html
+++ b/frontend/src/app/admin/population/import/import.component.html
@@ -77,7 +77,7 @@
         <div class="error-row" *ngIf="item.status === 'error' && item.errorMessage">
             <div class="error-message">
                 <i class="pi pi-exclamation-triangle"></i>
-                <span>{{ item.errorMessage }}</span>
+                <span style="white-space: pre-wrap;">{{ item.errorMessage }}</span>
             </div>
         </div>
     </div>

--- a/frontend/src/app/admin/population/import/import.component.ts
+++ b/frontend/src/app/admin/population/import/import.component.ts
@@ -363,20 +363,41 @@ export class ImportComponent implements AfterViewInit, OnDestroy {
   }
 
   /**
-   * Extract meaningful error message from HTTP error response
+   * Extract meaningful error message from HTTP error response.
+   *
+   * The Ampersand backend returns invariant violations in the response body
+   * under `notifications.invariants`. Each entry has a `ruleMessage` and
+   * an array of `tuples` with `violationMessage` strings.
    */
   private extractErrorMessage(error: any, fileName: string): string {
     try {
+      const body = error?.error;
+
+      // Priority 0: Invariant violations from the Ampersand backend
+      const invariants = body?.notifications?.invariants;
+      if (Array.isArray(invariants) && invariants.length > 0) {
+        const lines: string[] = [];
+        for (const inv of invariants) {
+          lines.push(inv.ruleMessage ?? 'Unknown rule violation');
+          if (Array.isArray(inv.tuples)) {
+            for (const t of inv.tuples) {
+              lines.push(`   ${t.violationMessage ?? ''}`);
+            }
+          }
+          lines.push(''); // blank line between rules
+        }
+        return lines.join('\n').trim();
+      }
+
       // Priority 1: Check for structured error response with msg
-      if (error?.error?.msg) {
-        const msg = error.error.msg;
+      if (body?.msg) {
         // The backend message already contains cell references, so use it directly
-        return msg;
+        return body.msg;
       }
 
       // Priority 2: Check for generic error.error field
-      if (error?.error?.error) {
-        return `Error in file "${fileName}": ${error.error.error}`;
+      if (body?.error) {
+        return `Error in file "${fileName}": ${body.error}`;
       }
 
       // Priority 3: Check for standard HTTP error message


### PR DESCRIPTION
## Problem

When a population import fails due to invariant violations (HTTP 400), the import UI shows a generic error message:

> Error in file "ParagrafenAA.xlsx": Http failure response for http://localhost/api/v1/admin/import: 400 Bad Request

The actual violation details (rule names, affected tuples) are present in the response body under `notifications.invariants`, but `extractErrorMessage()` never looks at that field.

## Solution

Add a Priority 0 check in `extractErrorMessage()` that reads `error.error.notifications.invariants` and formats each violation with its rule message and tuple details into a multiline string. Add `white-space: pre-wrap` to the error message span so newlines render correctly.

## Changes

- `import.component.ts`: extract and format invariant violations from the API response body
- `import.component.html`: add `white-space: pre-wrap` style for multiline error display

## Example output after fix

```
Violation of rule 'VrijvanTekst'
   Eis_774b...[Eis],u00332[Uitspraak]
   Eis_a4c3...[Eis],u00333[Uitspraak]

Each ProductNaam may only have one Product in the relation voorkeursNaam
   Solanum tuberosum[ProductNaam],Solanum tuberosum[ProductNaam]
```

## Version

This is a backwards compatible bugfix. Proposed tag: **v2.0.8**
