### PR TITLE
ci: dependabot grouping + cooldown + auto-merge for patch/minor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,48 @@
+version: 2
+
+# Dependency update configuration.
+#
+# Updates are grouped (one PR per ecosystem for minor+patch) to cut down on PR noise,
+# and held back with a cooldown so that freshly-published — and possibly compromised —
+# versions are not adopted immediately. Major updates are intentionally left ungrouped
+# so they surface as individual PRs and are reviewed/merged by hand.
+updates:
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    # Wait before adopting a newly published version, so yanked/compromised
+    # releases can be discovered by the wider community first.
+    cooldown:
+      default-days: 7
+    groups:
+      frontend:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+    groups:
+      backend:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,40 @@
+name: Dependabot auto-merge
+
+# Automatically enable auto-merge for Dependabot patch/minor updates.
+#
+# Security notes:
+#   * The job only runs for PRs whose actor is genuinely `dependabot[bot]`
+#     (`github.actor` cannot be spoofed), so an attacker cannot trigger it by
+#     pushing a `dependabot/*`-named branch.
+#   * Only patch and minor updates are auto-merged; major updates are left for
+#     manual review.
+#   * `gh pr merge --auto` only QUEUES the merge; it completes after the required
+#     status checks (e.g. "Regression tests") pass, so a bump that breaks the
+#     build never lands. (This does not catch silent malware — the cooldown in
+#     dependabot.yml is the mitigation for that.)
+#   * This workflow never checks out or runs the PR's code, so it cannot be
+#     abused to execute untrusted code with the elevated token.
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch/minor updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Sets up dependency-update automation:

- **Grouping + cooldown** (`.github/dependabot.yml`): minor+patch grouped into one PR/week per ecosystem (npm `/frontend`, composer `/`, github-actions); 7-day cooldown so freshly published versions aren't adopted immediately (supply-chain mitigation).
- **Auto-merge** (`.github/workflows/dependabot-auto-merge.yml`): genuine `dependabot[bot]` patch/minor PRs auto-merge after required checks pass; **majors stay manual**; the workflow never runs PR code.

Requires (set separately): repo `allow_auto_merge` enabled and "Regression tests" as a required status check so auto-merge waits for a green build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)