### PR TITLE
fix(test): update hello-world to modern RELATION syntax

### DIFF
--- a/test/projects/hello-world/model/example.adl
+++ b/test/projects/hello-world/model/example.adl
@@ -3,7 +3,7 @@ PURPOSE CONTEXT HelloWorld
 {+This script allows you to check whether or not you can actually use Ampersand.+}
 
 REPRESENT MyName TYPE ALPHANUMERIC
-sessionMyName :: SESSION * MyName [UNI]
+RELATION sessionMyName[SESSION*MyName] [UNI]
 MEANING "My name can be known in the current session."
 
 ROLE User MAINTAINS PleaseClickOnRegistrationToSpecifyYourName
@@ -14,7 +14,7 @@ INTERFACE Registration: "_SESSION"[SESSION] cRud BOX<TABLE>
    [ "My name is" : sessionMyName cRUd 
    ]
 
-sayHelloReq :: SESSION * SESSION [PROP]
+RELATION sayHelloReq[SESSION*SESSION] [PROP]
 ROLE ExecEngine MAINTAINS SayHelloWhenNameIsSpecified
 RULE SayHelloWhenNameIsSpecified LABEL "Say hello when name is specified": "_SESSION"[SESSION] /\ sessionMyName;sessionMyName~ |- sayHelloReq
 VIOLATION (TXT "{EX} SetNavToOnCommit;/Hello_44__32_World"


### PR DESCRIPTION
The `hello-world` test project used the deprecated `::` relation declaration syntax, which the bundled Ampersand compiler (20260617) rejects — breaking `./generate.sh hello-world` (parse error at `example.adl:6`).

Both declarations are converted to modern `RELATION name[Src*Tgt] [props]` syntax. Verified: `./generate.sh hello-world` now compiles, installs, and serves the standard home (with the new search module) cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)