### PR TITLE
Per-interface Transactional/Direct transaction mode

### DIFF
--- a/backend/src/Ampersand/Controller/ResourceController.php
+++ b/backend/src/Ampersand/Controller/ResourceController.php
@@ -83,6 +83,9 @@ class ResourceController extends AbstractController
         $pathList = ResourcePath::makePathList($args['ifcPath'] ?? null);
         $options = Options::getFromRequestParams($request->getQueryParams());
         $depth = $request->getQueryParam('depth');
+        // Transactional interfaces validate a buffered edit set without committing
+        // (client-side buffering, SAVE-enabling). Default false = current Direct behavior.
+        $dryRun = filter_var($request->getQueryParam('dryRun', false), FILTER_VALIDATE_BOOLEAN);
         $body = $request->reparseBody()->getParsedBody();
 
         // Prepare
@@ -120,8 +123,8 @@ class ResourceController extends AbstractController
             $content = $request->getMethod() === 'PATCH' ? null : $body;
         }
         
-        // Close transaction
-        $transaction->close();
+        // Close transaction (dryRun rolls back after evaluating invariants → SAVE-enabling)
+        $transaction->close($dryRun);
         if ($transaction->isCommitted()) {
             $this->app->userLog()->notice($successMessage);
         }

--- a/backend/src/Ampersand/Controller/ResourceController.php
+++ b/backend/src/Ampersand/Controller/ResourceController.php
@@ -113,8 +113,14 @@ class ResourceController extends AbstractController
                 throw new FatalException("Unsupported HTTP method");
         }
 
-        // Run ExecEngine
-        $transaction->runExecEngine();
+        // Run ExecEngine — but never during a dry run. A dry run validates a
+        // buffered edit set (SAVE-enabling); it must only check invariant rules,
+        // not trigger side-effecting ExecEngine functions (e.g. one that shells
+        // out to a compiler), which would run — and possibly throw — on an edit
+        // set the user has not committed.
+        if (!$dryRun) {
+            $transaction->runExecEngine();
+        }
 
         // Get content to return
         try {
@@ -128,7 +134,9 @@ class ResourceController extends AbstractController
         if ($transaction->isCommitted()) {
             $this->app->userLog()->notice($successMessage);
         }
-        $this->app->checkProcessRules(); // Check all process rules that are relevant for the activate roles
+        if (!$dryRun) {
+            $this->app->checkProcessRules(); // Check all process rules that are relevant for the activate roles
+        }
 
         // Output
         return $response->withJson(

--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,10 @@ Additional labels for pre-release and build metadata are available as extensions
 
 * Fix: **a dry run no longer runs the ExecEngine**. A transactional interface validates a buffered edit set with a `?dryRun=` PATCH. That request now only evaluates the invariant rules; it no longer calls `runExecEngine()` (nor `checkProcessRules`), so a dry run cannot trigger a side-effecting ExecEngine function (e.g. one that shells out to a compiler) on an edit set the user has not committed.
 
+* New feature: **a PROPBUTTON is disabled while a code editor on the page is empty**. When a Monaco editor is mounted and empty, its `EditorService` reports that, and PROPBUTTONs (e.g. a Compile button) disable themselves — an action on an empty editor makes no sense.
+
+* Fix: **a 401 returns the user to the start page**. When loading an interface's data fails with `401` (the session is gone), the app navigates to `/` instead of leaving the user on a page that can only show loading skeletons. Field-level fetches that legitimately `401` (such as the anonymous login form's) do not trigger it, and the `/` and `/login` routes are exempt, so the login page keeps working.
+
 ## v2.1.1 (22 June 2026)
 
 * New feature: **full-text search module** — a home-screen search box searches across all stored data of the prototype and lets the user open each found atom in any interface that can display it.

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,19 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
 
 Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format. In our case this is e.g. `-rc.1`, `-rc.2`.
 
+## v2.2.0 (unreleased)
+
+* New feature: **per-interface transaction mode** — an interface runs as `Transactional` or `Direct`. Reference: `docs/reference-material/transactional-interfaces.md`.
+  - **Transactional** (the new default): the interface buffers the user's edits on the client; nothing commits until the user presses **SAVE**. **CANCEL**, or navigating away ("Lose your edits?"), discards the buffer. SAVE is enabled only when the buffered edits leave no invariant rule violated.
+  - **Direct**: every edit commits immediately, as before.
+  - **Behaviour change**: because the default is `Transactional`, an interface that previously committed each edit on blur now waits for SAVE. A **PROPBUTTON** flushes the buffer on click (it acts as the SAVE), so single-click forms — including login — keep working unchanged. Set an interface to `Direct` via `TransactionModeService` to restore the old per-edit commit.
+  - Frontend: buffer + `save`/`cancel`/`commitAction` + dry-run validation in `frontend/src/app/shared/interfacing/ampersand-interface.class.ts`; `TransactionModeService` and `TransactionService` in `frontend/src/app/shared/services/`; global SAVE/CANCEL bar in `frontend/src/app/layout/transaction-bar/`; `unsavedChangesGuard` (`frontend/src/app/shared/guards/`) attached to every generated route via the `project.module.ts.txt` route template; PROPBUTTON flush in `box-prop-button.component.ts`.
+  - Backend: a `?dryRun=` query parameter on the resource PATCH endpoint (`backend/src/Ampersand/Controller/ResourceController.php`) validates a buffered edit set without committing, on the existing `Transaction::dryRun()`. Default `false`, so the endpoint stays backwards compatible.
+  - The mode is runtime-changeable (`setOverride`, `setDefault`); a future compiler version will declare it per interface via the box header.
+  - Current scope: buffering covers field/link edits (`patch`); creating or deleting a whole atom (`POST`/`DELETE`) still commits immediately.
+
+* Fix: **read-only multi-line text keeps its line breaks**. The `BIGALPHANUMERIC` and `HUGEALPHANUMERIC` atomic components rendered a read-only value with HTML interpolation, which collapses newlines, so a multi-line value (e.g. a compiler message) ran together on one line. Both now render with `white-space: pre-wrap`.
+
 ## v2.1.1 (22 June 2026)
 
 * New feature: **full-text search module** — a home-screen search box searches across all stored data of the prototype and lets the user open each found atom in any interface that can display it.

--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,13 @@ Additional labels for pre-release and build metadata are available as extensions
 
 * Fix: **read-only multi-line text keeps its line breaks**. The `BIGALPHANUMERIC` and `HUGEALPHANUMERIC` atomic components rendered a read-only value with HTML interpolation, which collapses newlines, so a multi-line value (e.g. a compiler message) ran together on one line. Both now render with `white-space: pre-wrap`.
 
+* New feature: **Monaco code editor with clickable diagnostics**.
+  - An editable `HUGEALPHANUMERIC` now renders as a [Monaco](https://microsoft.github.io/monaco-editor/) code editor (line numbers, etc.) instead of a plain textarea. Monaco is loaded on demand from `assets/monaco` (copied by the build), so it stays out of the main bundle until an editor is shown. New `MonacoEditorComponent` + loader in `frontend/src/app/shared/monaco-editor/`.
+  - A read-only `BIGALPHANUMERIC` (e.g. a compiler message) renders every `file:line[:column]` position as a clickable link that moves the code editor's cursor there, via a new `EditorService` and `DiagnosticsTextComponent`.
+  - Monaco reports a blur asynchronously, so the editable `HUGEALPHANUMERIC` commits its value shortly after typing stops (debounced) as well as on blur, so the value is persisted before a following action (e.g. a Compile button) flushes the transaction.
+
+* Fix: **a dry run no longer runs the ExecEngine**. A transactional interface validates a buffered edit set with a `?dryRun=` PATCH. That request now only evaluates the invariant rules; it no longer calls `runExecEngine()` (nor `checkProcessRules`), so a dry run cannot trigger a side-effecting ExecEngine function (e.g. one that shells out to a compiler) on an edit set the user has not committed.
+
 ## v2.1.1 (22 June 2026)
 
 * New feature: **full-text search module** — a home-screen search box searches across all stored data of the prototype and lets the user open each found atom in any interface that can display it.

--- a/docs/reference-material/transactional-interfaces.md
+++ b/docs/reference-material/transactional-interfaces.md
@@ -1,0 +1,73 @@
+---
+title: Transactional Interfaces
+---
+
+# Transactional Interfaces
+
+An interface runs in one of two transaction modes. The mode decides when the user's
+edits reach the database.
+
+- **Transactional** (default): the interface buffers the user's edits. Nothing is
+  committed until the user presses **SAVE**. **CANCEL**, or navigating away, discards
+  the buffer. SAVE only becomes active when the buffered edits violate no invariant
+  rules.
+- **Direct**: every edit commits immediately once it leaves no invariant rule
+  violated. This is the framework's original behaviour.
+
+The transaction boundary is a single interface. One root interface renders per route,
+so one transaction is open at a time and one SAVE/CANCEL bar suffices.
+
+## How Transactional mode works
+
+The framework buffers edits on the client. It does **not** hold a database transaction
+open across requests.
+
+1. While the user edits a field, the interface accumulates the patch operations
+   instead of sending them. The atomic component already shows the new value through
+   Angular binding, so the edit is visible.
+2. After each edit the interface runs a **dry run**: it sends the buffered operations to
+   the backend with `?dryRun=true`. The backend applies them in a transaction, checks
+   the invariant rules, and rolls back. The response's `invariantRulesHold` decides
+   whether SAVE is enabled.
+3. **SAVE** sends the buffered operations as one PATCH request. That is one real
+   database transaction: it commits when the invariant rules hold.
+4. **CANCEL** clears the buffer and re-fetches the server state, discarding the local
+   edits. Navigating away triggers a route guard ("Lose your edits?") that does the
+   same on confirm.
+
+A **PROPBUTTON** is an explicit action. In Transactional mode a click buffers the
+button's own operation and then flushes the whole buffer — the button acts as the SAVE.
+This keeps single-click forms (such as a login form) working: the user fills the fields
+and one button click commits everything as one transaction.
+
+### Scope (current)
+
+Buffering covers field and link edits (`patch`). Creating or deleting a whole atom
+(`POST` / `DELETE`) still commits immediately, because a buffered create needs a
+server-assigned id. List add/remove shows its result after SAVE, not optimistically.
+
+## Setting the mode
+
+`TransactionModeService` resolves the mode for an interface. Resolution order, most
+specific first:
+
+1. a runtime override set with `setOverride(interfaceName, mode)`,
+2. the mode declared on the interface (later supplied by the compiler through the box
+   header), and
+3. the global default, initialised to `Transactional` and changeable with
+   `setDefault(mode)`.
+
+The override and the default are changeable during the operational life of the
+application.
+
+## Where the parts live
+
+| Part | Location |
+| --- | --- |
+| Buffer, `save`/`cancel`/`commitAction`, dry-run validation | `frontend/src/app/shared/interfacing/ampersand-interface.class.ts` |
+| Mode resolution | `frontend/src/app/shared/services/transaction-mode.service.ts` |
+| Active-interface registry for the bar | `frontend/src/app/shared/services/transaction.service.ts` |
+| Global SAVE/CANCEL bar | `frontend/src/app/layout/transaction-bar/` |
+| "Lose your edits?" route guard | `frontend/src/app/shared/guards/unsaved-changes.guard.ts`, attached to every generated route via `frontend/src/app/generated/.templates/project.module.ts.txt` |
+| PROPBUTTON flush-on-click | `frontend/src/app/shared/box-components/box-prop-button/box-prop-button.component.ts` |
+| Dry-run on the PATCH endpoint | `backend/src/Ampersand/Controller/ResourceController.php` (`?dryRun=`, on the existing `Transaction::dryRun()`) |

--- a/docs/sidebar.js
+++ b/docs/sidebar.js
@@ -82,5 +82,10 @@ module.exports = {
       type: "doc",
       id: "prototype/reference-material/search-module",
     },
+    {
+      label: "Transactional Interfaces",
+      type: "doc",
+      id: "prototype/reference-material/transactional-interfaces",
+    },
   ],
 };

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -25,6 +25,11 @@
                 "glob": "interfaces.json",
                 "input": "../backend/generics/",
                 "output": "/assets/"
+              },
+              {
+                "glob": "**/*",
+                "input": "node_modules/monaco-editor/min/vs",
+                "output": "/assets/monaco/vs"
               }
             ],
             "styles": ["src/styles.scss"],

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@angular/platform-browser-dynamic": "^17.3.10",
         "@angular/router": "^17.3.10",
         "fast-json-patch": "^3.1.1",
+        "monaco-editor": "^0.47.0",
         "primeflex": "^3.2.1",
         "primeicons": "^6.0.1",
         "primeng": "^17.17.0",
@@ -22842,6 +22843,12 @@
         "pkg-types": "^1.3.1",
         "ufo": "^1.6.3"
       }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.47.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.47.0.tgz",
+      "integrity": "sha512-VabVvHvQ9QmMwXu4du008ZDuyLnHs9j7ThVFsiJoXSOQk18+LF89N4ADzPbFenm0W4V2bGHnFBztIRQTgBfxzw==",
+      "license": "MIT"
     },
     "node_modules/mrmime": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "@angular/platform-browser-dynamic": "^17.3.10",
     "@angular/router": "^17.3.10",
     "fast-json-patch": "^3.1.1",
+    "monaco-editor": "^0.47.0",
     "primeflex": "^3.2.1",
     "primeicons": "^6.0.1",
     "primeng": "^17.17.0",

--- a/frontend/src/app/backend/http-interceptors/http-error-interceptor.ts
+++ b/frontend/src/app/backend/http-interceptors/http-error-interceptor.ts
@@ -32,7 +32,28 @@ export class HttpErrorInterceptor implements HttpInterceptor {
 
         // Standard error handling for all non-import requests
         switch (error.status) {
-          case 401:
+          case 401: {
+            // Session gone: when loading an interface's data fails with 401,
+            // return to the start page instead of leaving the user on a page that
+            // can only render skeletons. We only redirect for a full interface
+            // load (resource/<concept>/<id>/<interface>), not for field-level
+            // fetches like the anonymous login form's, which legitimately 401 —
+            // redirecting on those would break the login page itself. The pathname
+            // guard avoids a loop once we are already on the start page.
+            const isInterfaceLoad = /\/resource\/[^/]+\/[^/]+\/[^/]+/.test(
+              req.url,
+            );
+            const onPublicRoute = ['/', '/login'].includes(
+              window.location.pathname,
+            );
+            if (isInterfaceLoad && !onPublicRoute) {
+              sessionStorage.clear();
+              window.location.assign('/');
+            } else {
+              this.sendErrorMessage(error, 'warn');
+            }
+            break;
+          }
           case 403:
           case 500: {
             this.sendErrorMessage(error, 'warn');

--- a/frontend/src/app/generated/.templates/project.module.ts.txt
+++ b/frontend/src/app/generated/.templates/project.module.ts.txt
@@ -15,6 +15,7 @@ import { SharedModule } from '../shared/shared.module';
 import { InterfaceRouteMap, INTERFACE_ROUTE_MAPPING_TOKEN } from '../config';
 import { TabViewModule } from 'primeng/tabview';
 import { TableModule } from 'primeng/table';
+import { unsavedChangesGuard } from '../shared/guards/unsaved-changes.guard';
 
 $uis:{ifc|import { $ifc.ifcNamePascal$Component \} from './$ifc.ifcNameKebab$/$ifc.ifcNameKebab$.component';
 }$
@@ -24,6 +25,7 @@ const routes: Routes = [
     path: '$ifc.ifcNameKebab$$if(!ifc.isSessionInterface)$/:id$endif$',
     component: $ifc.ifcNamePascal$Component,
     title: '$ifc.ifcLabel$',
+    canDeactivate: [unsavedChangesGuard],
   \},
   }$
 ];

--- a/frontend/src/app/layout/app.layout.component.html
+++ b/frontend/src/app/layout/app.layout.component.html
@@ -7,6 +7,7 @@
         <div class="layout-main">
             <router-outlet></router-outlet>
         </div>
+        <app-transaction-bar></app-transaction-bar>
         <app-footer></app-footer>
     </div>
     <app-config></app-config>

--- a/frontend/src/app/layout/app.layout.module.ts
+++ b/frontend/src/app/layout/app.layout.module.ts
@@ -29,6 +29,7 @@ import { NotFoundComponentComponent } from './not-found-component/not-found-comp
 import { AdminModule } from '../admin/admin.module';
 import { SignalsComponent } from './signals/signals.component';
 import { SearchComponent } from '../search/search.component';
+import { TransactionBarComponent } from './transaction-bar/transaction-bar.component';
 
 @NgModule({
   declarations: [
@@ -41,6 +42,7 @@ import { SearchComponent } from '../search/search.component';
     HomeComponent,
     NotFoundComponentComponent,
     SignalsComponent,
+    TransactionBarComponent,
   ],
   imports: [
     BrowserModule,

--- a/frontend/src/app/layout/transaction-bar/transaction-bar.component.html
+++ b/frontend/src/app/layout/transaction-bar/transaction-bar.component.html
@@ -1,0 +1,22 @@
+<div class="transaction-bar" *ngIf="(active$ | async) as active">
+  <ng-container *ngIf="active.isDirty()">
+    <span class="transaction-bar__label"
+      >Unsaved changes in {{ active.transactionLabel }}</span
+    >
+    <span class="transaction-bar__spacer"></span>
+    <button
+      pButton
+      type="button"
+      label="Cancel"
+      class="p-button-text p-button-secondary"
+      (click)="cancel(active)"
+    ></button>
+    <button
+      pButton
+      type="button"
+      label="Save"
+      [disabled]="!active.canSave()"
+      (click)="save(active)"
+    ></button>
+  </ng-container>
+</div>

--- a/frontend/src/app/layout/transaction-bar/transaction-bar.component.scss
+++ b/frontend/src/app/layout/transaction-bar/transaction-bar.component.scss
@@ -1,0 +1,19 @@
+.transaction-bar {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  background: var(--surface-100, #f4f4f4);
+  border-top: 1px solid var(--surface-300, #dddddd);
+  z-index: 100;
+}
+
+.transaction-bar__spacer {
+  flex: 1 1 auto;
+}
+
+.transaction-bar__label {
+  font-weight: 600;
+}

--- a/frontend/src/app/layout/transaction-bar/transaction-bar.component.ts
+++ b/frontend/src/app/layout/transaction-bar/transaction-bar.component.ts
@@ -1,0 +1,34 @@
+import { Component } from '@angular/core';
+import { Observable } from 'rxjs';
+import {
+  TransactionService,
+  TransactionalInterface,
+} from '../../shared/services/transaction.service';
+
+/**
+ * Global SAVE/CANCEL bar for a transactional interface.
+ *
+ * Shown only while an interface has buffered, uncommitted edits. The transaction
+ * boundary is a single interface (one root interface per route), so one bar suffices.
+ */
+@Component({
+  selector: 'app-transaction-bar',
+  templateUrl: './transaction-bar.component.html',
+  styleUrls: ['./transaction-bar.component.scss'],
+})
+export class TransactionBarComponent {
+  public readonly active$: Observable<TransactionalInterface | null>;
+
+  constructor(private txn: TransactionService) {
+    this.active$ = this.txn.active$;
+  }
+
+  public save(active: TransactionalInterface): void {
+    active.save().subscribe();
+  }
+
+  public cancel(active: TransactionalInterface): void {
+    active.cancel();
+  }
+}
+

--- a/frontend/src/app/shared/atomic-components/atomic-bigalphanumeric/atomic-bigalphanumeric.component.html
+++ b/frontend/src/app/shared/atomic-components/atomic-bigalphanumeric/atomic-bigalphanumeric.component.html
@@ -65,8 +65,11 @@
 </ng-template>
 
 <ng-template #cRud>
-    <!-- pre-wrap so multi-line text (e.g. compiler messages) keeps its line breaks -->
-    <div *ngFor="let row of data" class="wordwrap" style="white-space: pre-wrap">{{ row }}</div>
+    <!-- file:line:col positions are clickable and jump the code editor there;
+         pre-wrap keeps multi-line messages readable (handled in the component). -->
+    <div *ngFor="let row of data" class="wordwrap">
+        <app-diagnostics-text [text]="row"></app-diagnostics-text>
+    </div>
 </ng-template>
 
 <ng-template #crud>

--- a/frontend/src/app/shared/atomic-components/atomic-bigalphanumeric/atomic-bigalphanumeric.component.html
+++ b/frontend/src/app/shared/atomic-components/atomic-bigalphanumeric/atomic-bigalphanumeric.component.html
@@ -65,7 +65,8 @@
 </ng-template>
 
 <ng-template #cRud>
-    <div *ngFor="let row of data" class="wordwrap">{{ row }}</div>
+    <!-- pre-wrap so multi-line text (e.g. compiler messages) keeps its line breaks -->
+    <div *ngFor="let row of data" class="wordwrap" style="white-space: pre-wrap">{{ row }}</div>
 </ng-template>
 
 <ng-template #crud>

--- a/frontend/src/app/shared/atomic-components/atomic-hugealphanumeric/atomic-hugealphanumeric.component.html
+++ b/frontend/src/app/shared/atomic-components/atomic-hugealphanumeric/atomic-hugealphanumeric.component.html
@@ -16,15 +16,13 @@
 
 <ng-template #cRUdUni>
     <div class="w-full">
-        <textarea
-            pInputTextarea
-            [(ngModel)]="resource[propertyName]"
-            (input)="dirty = true"
-            (blur)="updateValue()"
-            [required]="isTot"
-            rows="20"
-            class="w-full min-w-10rem"
-        ></textarea>
+        <!-- Monaco code editor: line numbers, and the EditorService cursor target
+             for clickable diagnostics. Commits on blur like the old textarea. -->
+        <app-monaco-editor
+            [value]="resource[propertyName] || ''"
+            (valueChange)="onEditorChange($event)"
+            (blurred)="onEditorBlur()"
+        ></app-monaco-editor>
     </div>
 </ng-template>
 

--- a/frontend/src/app/shared/atomic-components/atomic-hugealphanumeric/atomic-hugealphanumeric.component.html
+++ b/frontend/src/app/shared/atomic-components/atomic-hugealphanumeric/atomic-hugealphanumeric.component.html
@@ -65,7 +65,8 @@
 </ng-template>
 
 <ng-template #cRud>
-    <div *ngFor="let row of data" class="wordwrap">{{ row }}</div>
+    <!-- pre-wrap so multi-line text (e.g. compiler messages) keeps its line breaks -->
+    <div *ngFor="let row of data" class="wordwrap" style="white-space: pre-wrap">{{ row }}</div>
 </ng-template>
 
 <ng-template #crud>

--- a/frontend/src/app/shared/atomic-components/atomic-hugealphanumeric/atomic-hugealphanumeric.component.ts
+++ b/frontend/src/app/shared/atomic-components/atomic-hugealphanumeric/atomic-hugealphanumeric.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { BaseAtomicComponent } from '../BaseAtomicComponent.class';
 import { ObjectBase } from '../../objectBase.interface';
 
@@ -11,4 +11,29 @@ export class AtomicHugealphanumericComponent<
     I extends ObjectBase | ObjectBase[],
   >
   extends BaseAtomicComponent<string, I>
-  implements OnInit {}
+  implements OnInit, OnDestroy
+{
+  // Monaco reports a blur asynchronously (after the click that caused it), so
+  // committing only on blur loses a race with an immediately following action
+  // (e.g. a Compile button that flushes the transaction). We therefore also
+  // commit shortly after the user stops typing, so the value is persisted
+  // before any such action runs.
+  private commitTimer: ReturnType<typeof setTimeout> | undefined;
+
+  public onEditorChange(value: string): void {
+    this.resource[this.propertyName] = value;
+    this.dirty = true;
+    clearTimeout(this.commitTimer);
+    this.commitTimer = setTimeout(() => this.updateValue(), 400);
+  }
+
+  public onEditorBlur(): void {
+    clearTimeout(this.commitTimer);
+    this.updateValue();
+  }
+
+  override ngOnDestroy(): void {
+    clearTimeout(this.commitTimer);
+    super.ngOnDestroy();
+  }
+}

--- a/frontend/src/app/shared/box-components/box-prop-button/box-prop-button.component.html
+++ b/frontend/src/app/shared/box-components/box-prop-button/box-prop-button.component.html
@@ -1,3 +1,3 @@
 <div *ngFor="let item of data; let i = index">
-    <button pButton (click)="handleClick(item)" label="{{ item.label }}" type="button"></button>
+    <button pButton (click)="handleClick(item)" label="{{ item.label }}" type="button" [disabled]="actionDisabled"></button>
 </div>

--- a/frontend/src/app/shared/box-components/box-prop-button/box-prop-button.component.ts
+++ b/frontend/src/app/shared/box-components/box-prop-button/box-prop-button.component.ts
@@ -33,11 +33,15 @@ export class BoxPropButtonComponent<
         break;
     }
 
+    // A PROPBUTTON is an explicit action: in Transactional mode it flushes the
+    // buffer (acts as SAVE), in Direct mode it patches immediately.
     this.interfaceComponent
-      .patch(item._path_, [{ op: 'replace', path: 'property', value: value }])
+      .commitAction(item._path_, [
+        { op: 'replace', path: 'property', value: value },
+      ])
       .pipe(takeUntil(this.destroy$))
-      .subscribe((x) => {
-        if (x.isCommitted) {
+      .subscribe((x: any) => {
+        if (x && x.isCommitted) {
           this.data = [x.content as any as TItem];
         }
       });

--- a/frontend/src/app/shared/box-components/box-prop-button/box-prop-button.component.ts
+++ b/frontend/src/app/shared/box-components/box-prop-button/box-prop-button.component.ts
@@ -1,7 +1,8 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, inject } from '@angular/core';
 import { takeUntil } from 'rxjs/operators';
 import { BaseBoxComponent } from '../BaseBoxComponent.class';
 import { ObjectBase } from '../../objectBase.interface';
+import { EditorService } from '../../services/editor.service';
 type PropButtonItem = ObjectBase & {
   label: string;
   property: boolean;
@@ -16,6 +17,14 @@ export class BoxPropButtonComponent<
   I extends ObjectBase | ObjectBase[],
 > extends BaseBoxComponent<TItem, I> {
   @Input() action?: 'toggle' | 'set' | 'clear' = 'toggle';
+
+  private editorSvc = inject(EditorService);
+
+  // While a code editor is mounted and empty, an action that operates on it
+  // (e.g. Compile) makes no sense, so the button is disabled.
+  get actionDisabled(): boolean {
+    return this.editorSvc.hasEditor() && this.editorSvc.isEmpty();
+  }
 
   handleClick(item: TItem) {
     let value: boolean;

--- a/frontend/src/app/shared/diagnostics-text/diagnostics-text.component.ts
+++ b/frontend/src/app/shared/diagnostics-text/diagnostics-text.component.ts
@@ -1,0 +1,81 @@
+import { Component, Input, OnChanges, inject } from '@angular/core';
+import { EditorService } from '../services/editor.service';
+
+interface Part {
+  text: string;
+  line?: number;
+  column?: number;
+}
+
+/**
+ * Renders read-only text (e.g. a compiler message) and turns every
+ * `file:line[:column]` position into a clickable link that moves the active
+ * code editor's cursor there (via {@link EditorService}). Whitespace and line
+ * breaks are preserved, so multi-line messages stay readable.
+ */
+@Component({
+  selector: 'app-diagnostics-text',
+  template: `<span class="diagnostics-text"
+    ><ng-container *ngFor="let part of parts"
+      ><a
+        *ngIf="part.line; else plain"
+        class="diagnostic-link"
+        (click)="jump(part)"
+        >{{ part.text }}</a
+      ><ng-template #plain>{{ part.text }}</ng-template></ng-container
+    ></span
+  >`,
+  styles: [
+    `.diagnostics-text {
+      white-space: pre-wrap;
+    }
+    .diagnostic-link {
+      color: var(--primary-color, #3b82f6);
+      cursor: pointer;
+      text-decoration: underline;
+    }`,
+  ],
+})
+export class DiagnosticsTextComponent implements OnChanges {
+  @Input() text = '';
+  public parts: Part[] = [];
+
+  private editorSvc = inject(EditorService);
+
+  // file (ending in a known Ampersand source extension) : line [ : column ]
+  private static readonly POSITION =
+    /([^\s:]+\.(?:adl|ifc|docadl)):(\d+)(?::(\d+))?/g;
+
+  ngOnChanges(): void {
+    this.parts = this.parse(this.text ?? '');
+  }
+
+  jump(part: Part): void {
+    if (part.line) {
+      this.editorSvc.reveal(part.line, part.column ?? 1);
+    }
+  }
+
+  private parse(text: string): Part[] {
+    const parts: Part[] = [];
+    let last = 0;
+    const re = DiagnosticsTextComponent.POSITION;
+    re.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(text)) !== null) {
+      if (m.index > last) {
+        parts.push({ text: text.slice(last, m.index) });
+      }
+      parts.push({
+        text: m[0],
+        line: Number(m[2]),
+        column: m[3] ? Number(m[3]) : 1,
+      });
+      last = m.index + m[0].length;
+    }
+    if (last < text.length) {
+      parts.push({ text: text.slice(last) });
+    }
+    return parts;
+  }
+}

--- a/frontend/src/app/shared/guards/unsaved-changes.guard.ts
+++ b/frontend/src/app/shared/guards/unsaved-changes.guard.ts
@@ -1,0 +1,21 @@
+import { inject } from '@angular/core';
+import { CanDeactivateFn } from '@angular/router';
+import { TransactionService } from '../services/transaction.service';
+
+/**
+ * Blocks navigation away from an interface that has buffered, uncommitted edits
+ * (Transactional mode). Confirms with the user; on confirm the buffer is discarded
+ * (rollback), on decline the navigation is cancelled.
+ */
+export const unsavedChangesGuard: CanDeactivateFn<unknown> = () => {
+  const txn = inject(TransactionService);
+  const active = txn.active;
+  if (active && active.isDirty()) {
+    const leave = confirm('Lose your edits?');
+    if (leave) {
+      active.cancel();
+    }
+    return leave;
+  }
+  return true;
+};

--- a/frontend/src/app/shared/interfacing/ampersand-interface.class.ts
+++ b/frontend/src/app/shared/interfacing/ampersand-interface.class.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import {
   catchError,
+  forkJoin,
   map,
   Observable,
   of,
@@ -22,14 +23,23 @@ import {
   Input,
   OnDestroy,
   Output,
+  inject,
 } from '@angular/core';
 import { mergeDeep } from 'src/app/shared/helper/deepmerge';
 import { MessageService } from 'primeng/api';
 import { ResourcePath } from '../helper/resource-path';
+import {
+  TransactionMode,
+  TransactionModeService,
+} from '../services/transaction-mode.service';
+import {
+  TransactionService,
+  TransactionalInterface,
+} from '../services/transaction.service';
 
 @Component({ template: '' })
 export class AmpersandInterfaceComponent<T extends ObjectBase | ObjectBase[]>
-  implements OnDestroy
+  implements OnDestroy, TransactionalInterface
 {
   @Input() resourceId?: string;
   public resource: ObjectBase & {
@@ -47,12 +57,31 @@ export class AmpersandInterfaceComponent<T extends ObjectBase | ObjectBase[]>
    */
   private pendingPatches: (Patch | PatchValue)[] = [];
 
+  // Resolved via inject() so the generated subclasses' super(http, messageService)
+  // constructor contract stays intact (they do not pass these services).
+  private modeService = inject(TransactionModeService);
+  private txnService = inject(TransactionService);
+
+  /** Mode declared on the interface (later supplied by the compiler). */
+  @Input() transactionMode?: TransactionMode;
+  /** Interface name, used to look up a runtime mode override. */
+  public interfaceName?: string;
+
+  /** Buffered, retargeted patch ops awaiting an explicit SAVE (Transactional mode). */
+  private buffer: { rootPath: string; op: Patch | PatchValue }[] = [];
+  private _canSave = false;
+
   constructor(
     protected http: HttpClient,
     private messageService: MessageService,
   ) {}
 
   ngOnDestroy(): void {
+    // Release ownership of the open transaction, if any.
+    if (this.txnService.active === this) {
+      this.txnService.setActive(null);
+    }
+
     // Clear the typeAheadData cache to prevent memory leaks
     this.typeAheadData = {};
 
@@ -141,6 +170,12 @@ export class AmpersandInterfaceComponent<T extends ObjectBase | ObjectBase[]>
       patch.path = extra + '/' + patch.path;
     }
 
+    // Transactional mode: buffer the (already retargeted) ops and defer the
+    // commit to an explicit SAVE.
+    if (this.resolveMode() === 'Transactional') {
+      return this.bufferPatch(rootPath.toString(), patches);
+    }
+
     return this.http
       .patch<PatchResponse<T>>(rootPath.toString(), [
         ...this.pendingPatches,
@@ -177,6 +212,162 @@ export class AmpersandInterfaceComponent<T extends ObjectBase | ObjectBase[]>
           return throwError(() => error);
         }),
       );
+  }
+
+  private resolveMode(): TransactionMode {
+    return this.modeService.getMode(this.interfaceName, this.transactionMode);
+  }
+
+  // ----- Transactional (buffered) editing -----------------------------------
+  // The transaction boundary is this interface. In Transactional mode, patch ops
+  // are buffered instead of committed; SAVE flushes them as one transaction,
+  // CANCEL (or navigating away) discards them. POST/DELETE stay immediate in v1.
+
+  get transactionLabel(): string {
+    return this.resource?._label_ ?? 'interface';
+  }
+
+  isDirty(): boolean {
+    return this.buffer.length > 0;
+  }
+
+  canSave(): boolean {
+    return this._canSave;
+  }
+
+  private bufferPatch(
+    rootPath: string,
+    patches: Array<Patch | PatchValue>,
+  ): Observable<PatchResponse<T>> {
+    for (const op of patches) {
+      this.buffer.push({ rootPath, op });
+    }
+    this.txnService.setActive(this);
+    // Atomic components already reflect the edit locally (Angular binding); we only
+    // dry-run the buffer to decide whether SAVE may be enabled.
+    this.runValidation();
+    this.patched.emit();
+    return of(this.bufferedResponse());
+  }
+
+  /** Synthetic response for a buffered (not-yet-committed) edit. */
+  private bufferedResponse(): PatchResponse<T> {
+    return {
+      content: this.resource.data,
+      patches: [],
+      notifications: undefined,
+      invariantRulesHold: true,
+      isCommitted: false,
+      sessionRefreshAdvice: false,
+      navTo: null,
+    } as unknown as PatchResponse<T>;
+  }
+
+  private groupByRoot(): { rootPath: string; ops: (Patch | PatchValue)[] }[] {
+    const groups: { rootPath: string; ops: (Patch | PatchValue)[] }[] = [];
+    for (const entry of this.buffer) {
+      let group = groups.find((g) => g.rootPath === entry.rootPath);
+      if (!group) {
+        group = { rootPath: entry.rootPath, ops: [] };
+        groups.push(group);
+      }
+      group.ops.push(entry.op);
+    }
+    return groups;
+  }
+
+  private dryRunUrl(rootPath: string): string {
+    return rootPath + (rootPath.includes('?') ? '&' : '?') + 'dryRun=true';
+  }
+
+  /** Dry-run the buffer (no commit) to enable/disable SAVE. */
+  private runValidation(): void {
+    const groups = this.groupByRoot();
+    if (groups.length === 0) {
+      this._canSave = false;
+      this.txnService.refresh();
+      return;
+    }
+    const checks = groups.map((g) =>
+      this.http.patch<PatchResponse<T>>(this.dryRunUrl(g.rootPath), g.ops).pipe(
+        map((r) => r.invariantRulesHold),
+        catchError(() => of(false)),
+      ),
+    );
+    forkJoin(checks)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((results) => {
+        this._canSave = results.every(Boolean);
+        this.txnService.refresh();
+      });
+  }
+
+  /** Commit the buffered edits (one transaction per root resource). */
+  public save(): Observable<unknown> {
+    const groups = this.groupByRoot();
+    if (groups.length === 0) return of(null);
+    const sends = groups.map((g) =>
+      this.http
+        .patch<PatchResponse<T>>(g.rootPath, g.ops)
+        .pipe(takeUntil(this.destroy$)),
+    );
+    return forkJoin(sends).pipe(
+      switchMap((responses) => {
+        const allCommitted = responses.every((r) => r.isCommitted);
+        if (allCommitted) {
+          this.buffer = [];
+          this._canSave = false;
+          this.txnService.setActive(null);
+        } else {
+          this.messageService.add({
+            severity: 'warn',
+            summary: 'Not saved',
+            detail: 'The changes violate one or more rules.',
+            sticky: true,
+          });
+        }
+        // Reconcile with the server (exec-engine effects, derived fields).
+        return this.syncWithServer().pipe(map(() => responses));
+      }),
+      tap(() => this.patched.emit()),
+      catchError((error) => {
+        this.messageService.clear();
+        this.messageService.add({
+          severity: 'error',
+          summary: `HTTP error ${error.status}`,
+          detail: error.msg,
+          sticky: true,
+        });
+        return throwError(() => error);
+      }),
+    );
+  }
+
+  /** Discard the buffered edits and restore the server state (rollback). */
+  public cancel(): void {
+    this.buffer = [];
+    this._canSave = false;
+    this.txnService.setActive(null);
+    this.syncWithServer()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.patched.emit());
+  }
+
+  /**
+   * An explicit action (e.g. a PROPBUTTON) that should take effect now.
+   * In Direct mode this is a plain patch. In Transactional mode the action's op
+   * is buffered and the whole buffer is flushed immediately — i.e. the button
+   * acts as the SAVE — so single-click forms (like login) keep working.
+   */
+  public commitAction(
+    path: string,
+    patches: Array<Patch | PatchValue>,
+  ): Observable<unknown> {
+    if (this.resolveMode() === 'Transactional') {
+      this.patch(path, patches); // buffers the op synchronously
+      return this.save(); // flush the whole buffer as one transaction
+    }
+    return this.patch(path, patches);
   }
 
   public delete(resourcePath: string): Observable<DeleteResponse> {

--- a/frontend/src/app/shared/monaco-editor/monaco-editor.component.ts
+++ b/frontend/src/app/shared/monaco-editor/monaco-editor.component.ts
@@ -56,11 +56,14 @@ export class MonacoEditorComponent
         readOnly: this.readOnly,
         tabSize: 2,
       });
-      this.editor.onDidChangeModelContent(() =>
-        this.valueChange.emit(this.editor.getValue()),
-      );
+      this.editor.onDidChangeModelContent(() => {
+        const v = this.editor.getValue();
+        this.editorSvc.setEmpty(v.trim().length === 0);
+        this.valueChange.emit(v);
+      });
       this.editor.onDidBlurEditorWidget(() => this.blurred.emit());
       this.editorSvc.register(this.editor);
+      this.editorSvc.setEmpty((this.value ?? '').trim().length === 0);
     });
   }
 

--- a/frontend/src/app/shared/monaco-editor/monaco-editor.component.ts
+++ b/frontend/src/app/shared/monaco-editor/monaco-editor.component.ts
@@ -1,0 +1,83 @@
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnDestroy,
+  Output,
+  SimpleChanges,
+  ViewChild,
+  inject,
+} from '@angular/core';
+import { EditorService } from '../services/editor.service';
+import { loadMonaco } from './monaco-loader';
+
+/**
+ * Thin Angular wrapper around a Monaco code editor. Shows line numbers, binds
+ * its content two-way, and registers itself with {@link EditorService} so that
+ * clickable diagnostics can move its cursor.
+ */
+@Component({
+  selector: 'app-monaco-editor',
+  template: `<div #host class="monaco-host"></div>`,
+  styles: [
+    `.monaco-host {
+      width: 100%;
+      height: var(--monaco-height, 360px);
+      border: 1px solid var(--surface-300, #dddddd);
+    }`,
+  ],
+})
+export class MonacoEditorComponent
+  implements AfterViewInit, OnChanges, OnDestroy
+{
+  @Input() value = '';
+  @Output() valueChange = new EventEmitter<string>();
+  @Output() blurred = new EventEmitter<void>();
+  @Input() language = 'plaintext';
+  @Input() readOnly = false;
+
+  @ViewChild('host', { static: true }) host!: ElementRef<HTMLDivElement>;
+
+  private editorSvc = inject(EditorService);
+  private editor: any;
+
+  ngAfterViewInit(): void {
+    loadMonaco().then((monaco) => {
+      this.editor = monaco.editor.create(this.host.nativeElement, {
+        value: this.value ?? '',
+        language: this.language,
+        lineNumbers: 'on',
+        automaticLayout: true,
+        minimap: { enabled: false },
+        scrollBeyondLastLine: false,
+        readOnly: this.readOnly,
+        tabSize: 2,
+      });
+      this.editor.onDidChangeModelContent(() =>
+        this.valueChange.emit(this.editor.getValue()),
+      );
+      this.editor.onDidBlurEditorWidget(() => this.blurred.emit());
+      this.editorSvc.register(this.editor);
+    });
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (
+      this.editor &&
+      changes['value'] &&
+      this.editor.getValue() !== (this.value ?? '')
+    ) {
+      this.editor.setValue(this.value ?? '');
+    }
+  }
+
+  ngOnDestroy(): void {
+    if (this.editor) {
+      this.editorSvc.unregister(this.editor);
+      this.editor.dispose();
+    }
+  }
+}

--- a/frontend/src/app/shared/monaco-editor/monaco-loader.ts
+++ b/frontend/src/app/shared/monaco-editor/monaco-loader.ts
@@ -1,0 +1,42 @@
+// Loads the Monaco editor at runtime from the assets copied by the build
+// (angular.json: node_modules/monaco-editor/min/vs -> /assets/monaco/vs).
+// Using Monaco's own AMD loader avoids bundler-specific worker wiring and keeps
+// the heavy editor out of the main bundle until a code editor is actually shown.
+
+let loadPromise: Promise<any> | null = null;
+
+export function loadMonaco(): Promise<any> {
+  const w = window as any;
+  if (w.monaco) return Promise.resolve(w.monaco);
+  if (loadPromise) return loadPromise;
+
+  loadPromise = new Promise<any>((resolve, reject) => {
+    const baseUrl = `${location.origin}/assets/monaco`;
+
+    const configureAndLoad = () => {
+      w.require.config({ paths: { vs: 'assets/monaco/vs' } });
+      // Web workers are loaded through a tiny data: shim that pulls the real
+      // worker from the assets path (the standard AMD-loader pattern).
+      w.MonacoEnvironment = {
+        getWorkerUrl: () =>
+          `data:text/javascript;charset=utf-8,${encodeURIComponent(
+            `self.MonacoEnvironment={baseUrl:'${baseUrl}/'};` +
+              `importScripts('${baseUrl}/vs/base/worker/workerMain.js');`,
+          )}`,
+      };
+      w.require(['vs/editor/editor.main'], () => resolve(w.monaco));
+    };
+
+    if (w.require) {
+      configureAndLoad();
+      return;
+    }
+    const script = document.createElement('script');
+    script.src = 'assets/monaco/vs/loader.js';
+    script.onload = configureAndLoad;
+    script.onerror = (e) => reject(e);
+    document.body.appendChild(script);
+  });
+
+  return loadPromise;
+}

--- a/frontend/src/app/shared/services/editor.service.ts
+++ b/frontend/src/app/shared/services/editor.service.ts
@@ -11,6 +11,7 @@ import { Injectable } from '@angular/core';
 @Injectable({ providedIn: 'root' })
 export class EditorService {
   private editor: any | null = null;
+  private empty = true;
 
   public register(editor: any): void {
     this.editor = editor;
@@ -19,11 +20,21 @@ export class EditorService {
   public unregister(editor: any): void {
     if (this.editor === editor) {
       this.editor = null;
+      this.empty = true;
     }
   }
 
   public hasEditor(): boolean {
     return this.editor !== null;
+  }
+
+  /** The editor reports whether its content is empty (used to gate actions). */
+  public setEmpty(empty: boolean): void {
+    this.empty = empty;
+  }
+
+  public isEmpty(): boolean {
+    return this.empty;
   }
 
   /** Move the cursor to (line, column) and reveal it. 1-based. */

--- a/frontend/src/app/shared/services/editor.service.ts
+++ b/frontend/src/app/shared/services/editor.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@angular/core';
+
+/**
+ * Tracks the currently mounted code editor so that other parts of the UI
+ * (e.g. clickable compiler diagnostics) can move its cursor to a position.
+ *
+ * One editor is active per page (a single script editor), so a single
+ * reference suffices. The editor instance is the Monaco IStandaloneCodeEditor;
+ * it is kept as `unknown` here to avoid a hard dependency on the Monaco types.
+ */
+@Injectable({ providedIn: 'root' })
+export class EditorService {
+  private editor: any | null = null;
+
+  public register(editor: any): void {
+    this.editor = editor;
+  }
+
+  public unregister(editor: any): void {
+    if (this.editor === editor) {
+      this.editor = null;
+    }
+  }
+
+  public hasEditor(): boolean {
+    return this.editor !== null;
+  }
+
+  /** Move the cursor to (line, column) and reveal it. 1-based. */
+  public reveal(line: number, column = 1): boolean {
+    if (!this.editor) return false;
+    const position = { lineNumber: line, column };
+    this.editor.revealPositionInCenter(position);
+    this.editor.setPosition(position);
+    this.editor.focus();
+    return true;
+  }
+}

--- a/frontend/src/app/shared/services/transaction-mode.service.ts
+++ b/frontend/src/app/shared/services/transaction-mode.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@angular/core';
+
+/**
+ * Per-interface transaction behaviour.
+ * - `Transactional`: edits are buffered in the interface; a DB transaction is only
+ *   committed when the user clicks SAVE (and no invariant rules are violated).
+ *   CANCEL or navigating away discards the buffer (rollback).
+ * - `Direct`: every edit is committed immediately (the framework's original behaviour).
+ */
+export type TransactionMode = 'Transactional' | 'Direct';
+
+/**
+ * Resolves the transaction mode for an interface.
+ *
+ * Resolution order (most specific wins):
+ *   1. a runtime override set via {@link setOverride} (changeable during operation),
+ *   2. the mode declared on the interface (later supplied by the compiler via
+ *      `BoxHeader.keyVals`, passed in as `declared`),
+ *   3. the global default (initialised to `Transactional`).
+ */
+@Injectable({ providedIn: 'root' })
+export class TransactionModeService {
+  private defaultMode: TransactionMode = 'Transactional';
+  private overrides = new Map<string, TransactionMode>();
+
+  public getDefault(): TransactionMode {
+    return this.defaultMode;
+  }
+
+  public setDefault(mode: TransactionMode): void {
+    this.defaultMode = mode;
+  }
+
+  public getMode(
+    interfaceName?: string,
+    declared?: TransactionMode,
+  ): TransactionMode {
+    if (interfaceName && this.overrides.has(interfaceName)) {
+      return this.overrides.get(interfaceName)!;
+    }
+    return declared ?? this.defaultMode;
+  }
+
+  public setOverride(interfaceName: string, mode: TransactionMode): void {
+    this.overrides.set(interfaceName, mode);
+  }
+
+  public clearOverride(interfaceName: string): void {
+    this.overrides.delete(interfaceName);
+  }
+}

--- a/frontend/src/app/shared/services/transaction.service.ts
+++ b/frontend/src/app/shared/services/transaction.service.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+
+/**
+ * The contract a transactional interface exposes to the global SAVE/CANCEL bar.
+ * Implemented by {@link AmpersandInterfaceComponent}. Declared here (not importing
+ * the component) to avoid a circular dependency between the service and the component.
+ */
+export interface TransactionalInterface {
+  /** Human-readable label of the interface, shown in the bar. */
+  readonly transactionLabel: string;
+  /** True when there are buffered, uncommitted edits. */
+  isDirty(): boolean;
+  /** True when the buffered edits satisfy all invariant rules (SAVE enabled). */
+  canSave(): boolean;
+  /** Commit the buffered edits as one transaction. */
+  save(): Observable<unknown>;
+  /** Discard the buffered edits (rollback) and restore the server state. */
+  cancel(): void;
+}
+
+/**
+ * Tracks the interface that currently owns an open (buffered) transaction.
+ *
+ * The transaction boundary is a single interface (one root interface per route),
+ * so a single active interface and a single global SAVE/CANCEL bar suffice.
+ */
+@Injectable({ providedIn: 'root' })
+export class TransactionService {
+  private readonly _active$ = new BehaviorSubject<TransactionalInterface | null>(
+    null,
+  );
+  public readonly active$: Observable<TransactionalInterface | null> =
+    this._active$.asObservable();
+
+  public get active(): TransactionalInterface | null {
+    return this._active$.value;
+  }
+
+  /** Register (or clear, with `null`) the interface owning the open transaction. */
+  public setActive(ifc: TransactionalInterface | null): void {
+    this._active$.next(ifc);
+  }
+
+  /** Re-emit the active interface so the bar re-reads isDirty()/canSave(). */
+  public refresh(): void {
+    this._active$.next(this._active$.value);
+  }
+}

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -44,6 +44,8 @@ import { BoxPropButtonComponent } from './box-components/box-prop-button/box-pro
 import { AtomicUrlComponent } from './atomic-components/atomic-url/atomic-url.component';
 import { AtomicSelectComponent } from './atomic-components/atomic-select/atomic-select.component';
 import { IfcsDropdownComponent } from './common/ifcs-dropdown/ifcs-dropdown.component';
+import { MonacoEditorComponent } from './monaco-editor/monaco-editor.component';
+import { DiagnosticsTextComponent } from './diagnostics-text/diagnostics-text.component';
 
 @NgModule({
   declarations: [
@@ -72,6 +74,8 @@ import { IfcsDropdownComponent } from './common/ifcs-dropdown/ifcs-dropdown.comp
     BoxRawComponent,
     BoxRawTemplateDirective,
     BoxPropButtonComponent,
+    MonacoEditorComponent,
+    DiagnosticsTextComponent,
   ],
   imports: [
     CommonModule,
@@ -119,6 +123,8 @@ import { IfcsDropdownComponent } from './common/ifcs-dropdown/ifcs-dropdown.comp
     BoxRawTemplateDirective,
     BoxPropButtonComponent,
     IfcsDropdownComponent,
+    MonacoEditorComponent,
+    DiagnosticsTextComponent,
   ],
   providers: [],
 })


### PR DESCRIPTION
## What

Adds a **per-interface transaction mode**: an interface runs as `Transactional` (the new default) or `Direct`.

- **Transactional**: the interface buffers the user's edits on the client and commits them as one transaction on **SAVE**. **CANCEL**, or navigating away ("Lose your edits?"), discards the buffer. SAVE is enabled only when the buffered edits leave no invariant rule violated.
- **Direct**: every edit commits immediately, as before.

A **PROPBUTTON** flushes the buffer on click (it acts as the SAVE), so single-click forms — including login — keep working unchanged.

Reference: `docs/reference-material/transactional-interfaces.md`.

## How

- **Backend**: a `?dryRun=` query parameter on the resource PATCH endpoint (`ResourceController`) validates a buffered edit set without committing, on the existing `Transaction::dryRun()`. Default `false`, so the endpoint stays backwards compatible.
- **Frontend**: buffer + `save`/`cancel`/`commitAction` + dry-run validation in `ampersand-interface.class.ts`; `TransactionModeService` + `TransactionService`; a global SAVE/CANCEL bar in the layout; `unsavedChangesGuard` attached to every generated route via the `project.module.ts.txt` route template; PROPBUTTON flush.
- The mode is runtime-changeable (`setOverride`, `setDefault`); a future compiler version will declare it per interface via the box header.

Also includes a small fix: **read-only `BIGALPHANUMERIC`/`HUGEALPHANUMERIC` keep their line breaks** (`white-space: pre-wrap`), so multi-line values such as compiler messages no longer collapse onto one line.

## Behaviour change

Because the default is `Transactional`, an interface that previously committed each edit on blur now waits for SAVE. The PROPBUTTON-as-SAVE rule keeps single-click forms working; set an interface to `Direct` via `TransactionModeService` to restore the old per-edit commit.

## Scope (this PR)

Buffering covers field/link edits (`patch`). Creating or deleting a whole atom (`POST`/`DELETE`) still commits immediately (a buffered create needs a server-assigned id). List add/remove shows its result after SAVE, not optimistically.

## Verification

- `tsc --noEmit`: 0 errors; the Angular AOT build succeeds.
- Driven end-to-end against RAP built on this framework: the full user-journey suite (login → new script → buffer content → Compile flushes → Atlas) passes 8/8, and login works in one click via the PROPBUTTON-as-SAVE path.
