### PR TITLE
Single-role role switcher

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,14 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
 
 Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format. In our case this is e.g. `-rc.1`, `-rc.2`.
 
+## Unreleased
+
+* New feature: **single-role role switcher**. The topbar role menu (`RolesComponent`) now treats a session as having exactly ONE active role:
+  - Selecting a role **activates only that role** and deactivates the others, so the menu reads as a single-choice list.
+  - The picker offers only the roles the user may choose — their allowed roles **except `Anonymous`** (Anonymous is reached via the separate Logout action, not the picker).
+  - The picker **hides itself** when there is nothing to choose (one selectable role or fewer).
+  - After a switch, if the current page is **not reachable** for the new role (its route is not among the role-filtered navbar `navs`/`new`, via the interface route map), the app **navigates back to the home page**. The side menu is refreshed for the new role.
+
 ## v2.1.1 (22 June 2026)
 
 * New feature: **full-text search module** — a home-screen search box searches across all stored data of the prototype and lets the user open each found atom in any interface that can display it.

--- a/frontend/src/app/admin/roles/roles.component.html
+++ b/frontend/src/app/admin/roles/roles.component.html
@@ -1,4 +1,4 @@
-<button class="p-link layout-topbar-button" label="Show" (click)="menu.toggle($event)">
+<button *ngIf="showPicker" class="p-link layout-topbar-button" label="Show" (click)="menu.toggle($event)">
     <i class="pi pi-user"></i>
     <span>Roles</span>
 </button>

--- a/frontend/src/app/admin/roles/roles.component.ts
+++ b/frontend/src/app/admin/roles/roles.component.ts
@@ -1,9 +1,18 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { takeUntil } from 'rxjs/operators';
 import { MenuItem } from 'primeng/api';
-import { SessionRole } from 'src/app/shared/interfacing/navbar.interface';
+import {
+  Navbar,
+  SessionRole,
+} from 'src/app/shared/interfacing/navbar.interface';
 import { BaseComponent } from 'src/app/shared/BaseComponent.class';
 import { RolesService } from './roles.service';
+import { MenuService } from 'src/app/layout/app.menu.service';
+import {
+  InterfaceRouteMap,
+  INTERFACE_ROUTE_MAPPING_TOKEN,
+} from '../../config';
 
 @Component({
   selector: 'app-roles',
@@ -12,8 +21,17 @@ import { RolesService } from './roles.service';
 })
 export class RolesComponent extends BaseComponent implements OnInit {
   public menuItems!: MenuItem[];
+  // The picker is shown only when there is something to choose, i.e. more than one
+  // selectable role (the user's allowed roles excluding Anonymous).
+  public showPicker = false;
 
-  constructor(private rolesService: RolesService) {
+  constructor(
+    private rolesService: RolesService,
+    private menuService: MenuService,
+    private router: Router,
+    @Inject(INTERFACE_ROUTE_MAPPING_TOKEN)
+    private interfaceRouteMap: InterfaceRouteMap,
+  ) {
     super();
   }
 
@@ -26,25 +44,69 @@ export class RolesComponent extends BaseComponent implements OnInit {
       .getRoles()
       .pipe(takeUntil(this.destroy$))
       .subscribe((roles) => {
-        // maps the roles into menuItems
-        this.menuItems = roles.map((role, index) => ({
+        // The picker offers only the roles the user may choose: their allowed
+        // roles except Anonymous (Anonymous is reached via the separate Logout
+        // action, not the picker).
+        const choosable = roles.filter((role) => role.id !== 'Anonymous');
+        // Hide the picker entirely when there is nothing to choose.
+        this.showPicker = choosable.length > 1;
+        // A session has exactly one active role, so the role menu reads as a
+        // single-choice list: the active role is marked, the others are not.
+        this.menuItems = choosable.map((role) => ({
           label: role.label,
           icon: role.active ? 'pi pi-check-circle' : 'pi pi-circle-off',
-          command: () => this.patchRole(roles, index),
+          command: () => this.selectRole(roles, roles.indexOf(role)),
         }));
       });
   }
 
-  private patchRole(roles: Array<SessionRole>, index: number): void {
+  private selectRole(roles: Array<SessionRole>, index: number): void {
+    if (roles[index].active) {
+      return; // already the active role; switching changes nothing
+    }
     this.rolesService
-      .patchRole(roles, index)
+      .activateRole(roles, index)
       .pipe(takeUntil(this.destroy$))
-      .subscribe((x) =>
-        // updates menuItems' icon
-        x[index].active
-          ? (this.menuItems[index].icon = 'pi pi-check-circle')
-          : (this.menuItems[index].icon = 'pi pi-circle-off'),
-      );
-    this.loadOrCreateMenu();
+      .subscribe(() => {
+        this.loadOrCreateMenu(); // refresh the single-active marker
+        this.menuService.refresh(); // rebuild the side menu for the new role
+        this.redirectIfPageNotAllowed();
+      });
+  }
+
+  /**
+   * After switching role, the current page may no longer be visible to the new
+   * role. If the current route is not among the routes the new role may reach,
+   * navigate back to the home page.
+   */
+  private redirectIfPageNotAllowed(): void {
+    this.rolesService
+      .getNavbar()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((navbar) => {
+        const allowed = this.allowedRoutes(navbar);
+        const current = this.router.url.split('?')[0];
+        const fits =
+          current === navbar.home ||
+          allowed.some(
+            (route) => current === route || current.startsWith(route + '/'),
+          );
+        if (!fits) {
+          this.router.navigateByUrl(navbar.home);
+        }
+      });
+  }
+
+  /** The base routes the active role may reach, per the (role-filtered) navbar. */
+  private allowedRoutes(navbar: Navbar): string[] {
+    const fromNavs = navbar.navs
+      .filter((nav) => nav.ifc)
+      .map((nav) => this.interfaceRouteMap[nav.ifc as string]);
+    const fromNew = (navbar.new ?? []).flatMap((btn) =>
+      btn.ifcs.map((ifc) => this.interfaceRouteMap[ifc.id]),
+    );
+    return [...fromNavs, ...fromNew, navbar.home].filter(
+      (route): route is string => Boolean(route),
+    );
   }
 }

--- a/frontend/src/app/admin/roles/roles.service.ts
+++ b/frontend/src/app/admin/roles/roles.service.ts
@@ -19,12 +19,21 @@ export class RolesService {
     return roles;
   }
 
-  public patchRole(
+  /**
+   * Activate exactly one role for the session: the chosen role becomes active
+   * and every other role is deactivated. A session therefore always has a
+   * single active role.
+   */
+  public activateRole(
     roles: Array<SessionRole>,
     roleIndex: number,
   ): Observable<Array<SessionRole>> {
-    roles[roleIndex].active = !roles[roleIndex].active; // reverses the boolean value
-    return this.http.patch<Array<SessionRole>>('app/roles', roles);
+    const next = roles.map((role, i) => ({ ...role, active: i === roleIndex }));
+    return this.http.patch<Array<SessionRole>>('app/roles', next);
+  }
+
+  public getNavbar(): Observable<Navbar> {
+    return this.http.get<Navbar>('app/navbar');
   }
 
   public isRole(role: Role): Observable<boolean> {


### PR DESCRIPTION
## What

Makes the topbar role menu treat a session as having **exactly one active role**, and turns it into a true single-choice picker.

- **Single-select**: selecting a role activates only that role and deactivates the others. The menu reads as a single-choice list (active role marked).
- **Anonymous-free picker**: the picker offers only the roles the user may choose — their allowed roles **except `Anonymous`**. Anonymous is reached via the separate Logout action, not the picker.
- **Hidden when nothing to choose**: the picker hides itself when the user has one selectable role or fewer.
- **Navigate-away on switch**: after switching, if the current page is not reachable for the new role (its route is not among the role-filtered navbar `navs`/`new`, resolved via the interface route map), the app navigates back to the home page. The side menu is refreshed for the new role.

## Files

- `frontend/src/app/admin/roles/roles.service.ts` — `activateRole()` (single-active PATCH), `getNavbar()`.
- `frontend/src/app/admin/roles/roles.component.ts` — single-select, picker filtering/visibility, redirect-on-switch.
- `frontend/src/app/admin/roles/roles.component.html` — hide the picker when there is nothing to choose.

## Notes

This is the generic framework side. It pairs with an application model that enforces a single active role per session (e.g. RAP's SIAM bridge), but does not depend on it. Verified end-to-end against RAP: login yields one active role, switching between roles sticks, the picker excludes Anonymous, and switching to a role that cannot see the current page redirects to home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)