### PR TITLE
feat(roles): activate exactly one role at a time

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,12 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
 
 Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format. In our case this is e.g. `-rc.1`, `-rc.2`.
 
+## v2.2.0 (unreleased)
+
+* New feature: **single active role** — the role switcher in the top bar now activates exactly one role at a time. Picking a role activates it and deactivates every other role, so a session always has a single active role (a single-choice list, not independently toggled roles). The picker hides itself when there is nothing to choose (at most one selectable role besides `Anonymous`); after switching it rebuilds the side menu and returns to the start page when the current page is not visible to the new role.
+  - Frontend only: `frontend/src/app/admin/roles/roles.service.ts` (`activateRole` replaces the toggling `patchRole`) plus `roles.component.ts` / `roles.component.html`.
+  - Pairs with Ampersand ≥ v5.6.2, which declares `PrototypeContext.sessionActiveRoles` as `[UNI]` (a session has at most one active role). The existing backend `setActiveRoles` / `toggleActiveRole` already apply the per-role active flags the switcher sends, so no backend change is needed.
+
 ## v2.1.1 (22 June 2026)
 
 * Bugfix import: **OBJECT atom identities longer than 254 characters are now deterministically shortened** to `<first 243 chars>_<10 hex chars of sha1(id)>` in `Atom::setId` (OBJECT case), so they stay unique within the `VARCHAR(255)` identity column. This covers both runtime importers (Excel + JSON population) and the API, because every atom is built via `new Atom`. The algorithm is byte-for-byte identical to the Ampersand compiler's `shortenObjectId` (Ampersand ≥ v5.6.1), so a compile-time-imported object atom and the same atom created at runtime map to the same database row. Shared known-answer vector: `"a" × 300 → "a" × 243 + "_003ef1ba9e"`.

--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
 
 Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format. In our case this is e.g. `-rc.1`, `-rc.2`.
 
-## v2.2.0 (unreleased)
+## v2.1.3 (30 June 2026)
 
 * New feature: **single active role** — the role switcher in the top bar now activates exactly one role at a time. Picking a role activates it and deactivates every other role, so a session always has a single active role (a single-choice list, not independently toggled roles). The picker hides itself when there is nothing to choose (at most one selectable role besides `Anonymous`); after switching it rebuilds the side menu and returns to the start page when the current page is not visible to the new role.
   - Frontend only: `frontend/src/app/admin/roles/roles.service.ts` (`activateRole` replaces the toggling `patchRole`) plus `roles.component.ts` / `roles.component.html`.

--- a/frontend/src/app/admin/roles/roles.component.html
+++ b/frontend/src/app/admin/roles/roles.component.html
@@ -1,4 +1,4 @@
-<button class="p-link layout-topbar-button" label="Show" (click)="menu.toggle($event)">
+<button *ngIf="showPicker" class="p-link layout-topbar-button" label="Show" (click)="menu.toggle($event)">
     <i class="pi pi-user"></i>
     <span>Roles</span>
 </button>

--- a/frontend/src/app/admin/roles/roles.component.ts
+++ b/frontend/src/app/admin/roles/roles.component.ts
@@ -1,9 +1,18 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
 import { takeUntil } from 'rxjs/operators';
 import { MenuItem } from 'primeng/api';
-import { SessionRole } from 'src/app/shared/interfacing/navbar.interface';
+import {
+  Navbar,
+  SessionRole,
+} from 'src/app/shared/interfacing/navbar.interface';
 import { BaseComponent } from 'src/app/shared/BaseComponent.class';
 import { RolesService } from './roles.service';
+import { MenuService } from 'src/app/layout/app.menu.service';
+import {
+  InterfaceRouteMap,
+  INTERFACE_ROUTE_MAPPING_TOKEN,
+} from '../../config';
 
 @Component({
   selector: 'app-roles',
@@ -12,8 +21,17 @@ import { RolesService } from './roles.service';
 })
 export class RolesComponent extends BaseComponent implements OnInit {
   public menuItems!: MenuItem[];
+  // The picker is shown only when there is something to choose, i.e. more than one
+  // selectable role (the user's allowed roles excluding Anonymous).
+  public showPicker = false;
 
-  constructor(private rolesService: RolesService) {
+  constructor(
+    private rolesService: RolesService,
+    private menuService: MenuService,
+    private router: Router,
+    @Inject(INTERFACE_ROUTE_MAPPING_TOKEN)
+    private interfaceRouteMap: InterfaceRouteMap,
+  ) {
     super();
   }
 
@@ -26,25 +44,69 @@ export class RolesComponent extends BaseComponent implements OnInit {
       .getRoles()
       .pipe(takeUntil(this.destroy$))
       .subscribe((roles) => {
-        // maps the roles into menuItems
-        this.menuItems = roles.map((role, index) => ({
+        // The picker offers only the roles the user may choose: their allowed
+        // roles except Anonymous (Anonymous is reached via the separate Logout
+        // action, not the picker).
+        const choosable = roles.filter((role) => role.id !== 'Anonymous');
+        // Hide the picker entirely when there is nothing to choose.
+        this.showPicker = choosable.length > 1;
+        // A session has exactly one active role, so the role menu reads as a
+        // single-choice list: the active role is marked, the others are not.
+        this.menuItems = choosable.map((role) => ({
           label: role.label,
           icon: role.active ? 'pi pi-check-circle' : 'pi pi-circle-off',
-          command: () => this.patchRole(roles, index),
+          command: () => this.selectRole(roles, roles.indexOf(role)),
         }));
       });
   }
 
-  private patchRole(roles: Array<SessionRole>, index: number): void {
+  private selectRole(roles: Array<SessionRole>, index: number): void {
+    if (roles[index].active) {
+      return; // already the active role; switching changes nothing
+    }
     this.rolesService
-      .patchRole(roles, index)
+      .activateRole(roles, index)
       .pipe(takeUntil(this.destroy$))
-      .subscribe((x) =>
-        // updates menuItems' icon
-        x[index].active
-          ? (this.menuItems[index].icon = 'pi pi-check-circle')
-          : (this.menuItems[index].icon = 'pi pi-circle-off'),
-      );
-    this.loadOrCreateMenu();
+      .subscribe(() => {
+        this.loadOrCreateMenu(); // refresh the single-active marker
+        this.menuService.refresh(); // rebuild the side menu for the new role
+        this.redirectIfPageNotAllowed();
+      });
+  }
+
+  /**
+   * After switching role, the current page may no longer be visible to the new
+   * role. If the current route is not among the routes the new role may reach,
+   * navigate back to the home page.
+   */
+  private redirectIfPageNotAllowed(): void {
+    this.rolesService
+      .getNavbar()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe((navbar) => {
+        const allowed = this.allowedRoutes(navbar);
+        const current = this.router.url.split('?')[0];
+        const fits =
+          current === navbar.home ||
+          allowed.some(
+            (route) => current === route || current.startsWith(route + '/'),
+          );
+        if (!fits) {
+          this.router.navigateByUrl(navbar.home);
+        }
+      });
+  }
+
+  /** The base routes the active role may reach, per the (role-filtered) navbar. */
+  private allowedRoutes(navbar: Navbar): string[] {
+    const fromNavs = navbar.navs
+      .filter((nav) => nav.ifc)
+      .map((nav) => this.interfaceRouteMap[nav.ifc as string]);
+    const fromNew = (navbar.new ?? []).flatMap((btn) =>
+      btn.ifcs.map((ifc) => this.interfaceRouteMap[ifc.id]),
+    );
+    return [...fromNavs, ...fromNew, navbar.home].filter(
+      (route): route is string => Boolean(route),
+    );
   }
 }

--- a/frontend/src/app/admin/roles/roles.service.ts
+++ b/frontend/src/app/admin/roles/roles.service.ts
@@ -19,12 +19,21 @@ export class RolesService {
     return roles;
   }
 
-  public patchRole(
+  /**
+   * Activate exactly one role for the session: the chosen role becomes active
+   * and every other role is deactivated. A session therefore always has a
+   * single active role.
+   */
+  public activateRole(
     roles: Array<SessionRole>,
     roleIndex: number,
   ): Observable<Array<SessionRole>> {
-    roles[roleIndex].active = !roles[roleIndex].active; // reverses the boolean value
-    return this.http.patch<Array<SessionRole>>('app/roles', roles);
+    const next = roles.map((role, i) => ({ ...role, active: i === roleIndex }));
+    return this.http.patch<Array<SessionRole>>('app/roles', next);
+  }
+
+  public getNavbar(): Observable<Navbar> {
+    return this.http.get<Navbar>('app/navbar');
   }
 
   public isRole(role: Role): Observable<boolean> {


### PR DESCRIPTION
## What

The top-bar **role switcher now activates exactly one role at a time**. Picking a role activates it and deactivates every other role, so a session always has a single active role — a single-choice list instead of independently toggled roles.

- `roles.service.ts`: `activateRole` (sends every choosable role with exactly one `active: true`) replaces the toggling `patchRole`.
- `roles.component.ts` / `.html`: single-choice menu; the picker hides when there is nothing to choose (at most one selectable role besides `Anonymous`); after switching it rebuilds the side menu and returns to the start page when the current page is not visible to the new role.

Frontend-only — the backend `setActiveRoles` / `toggleActiveRole` already apply the per-role active flags the switcher sends.

## Why

Consolidates the single-active-role behaviour (validated in RAP) into the framework, so every prototype gets it without per-project customization.

## Pairs with

`AmpersandTarski/Ampersand` PR *"a session has at most one active role"* (Ampersand ≥ v5.6.2), which declares `PrototypeContext.sessionActiveRoles` as `[UNI]`. Release together so the model invariant and the single-select UI match.

## Verification

This exact frontend is what `ampersand-rap` (v2) builds and runs today: login yields one active role and switching between roles sticks. Imports it relies on (`INTERFACE_ROUTE_MAPPING_TOKEN`, `MenuService`) already exist on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
