### PR TITLE
ci: generate frontend code before the Storybook build

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -41,6 +41,23 @@ jobs:
         directory: frontend/coverage
         flags: frontend
         
+    # The Storybook build compiles the full Angular app, which imports the
+    # generated ./generated/project.module. That code is produced by the
+    # Ampersand compiler and is gitignored, so generate it here (from the
+    # hello-world example) before building. Mirrors generate.sh.
+    # NOTE! Keep this compiler image in sync with the Dockerfile / compiler-version.txt.
+    - name: Generate frontend code (hello-world)
+      run: |
+        docker run --rm \
+          -v ${{ github.workspace }}:/workspace \
+          --entrypoint /bin/ampersand \
+          ampersandtarski/ampersand:v5.6.1 \
+          proto --frontend-version Angular --no-backend \
+          /workspace/test/projects/hello-world/model/main.adl \
+          --proto-dir /workspace/frontend/src/app/generated \
+          --crud-defaults cRud --verbose
+        sudo chown -R "$USER" frontend/src/app/generated
+
     - name: Build Storybook
       run: |
         cd frontend


### PR DESCRIPTION
## Probleem
De "Frontend tests"-job bouwt Storybook, wat de volledige Angular-app compileert. Die importeert `./generated/project.module` — gegenereerde, gitignored code. In een schone CI-checkout ontbreekt dat, dus de build faalde met `TS2307: Cannot find module './generated/project.module'`. Dit blokkeerde alle dependabot-PR's die `frontend/**` raken, ongeacht de bump.

## Fix
Genereer de frontend-code met de Ampersand-compiler (hello-world voorbeeld) vóór de Storybook-build, analoog aan `generate.sh`. Zo weerspiegelt de check de dependency-wijziging in plaats van ontbrekende gegenereerde code.

- compiler-image `ampersandtarski/ampersand:v5.6.1` (in sync met Dockerfile / compiler-version.txt)
- `--no-backend --frontend-version Angular` → schrijft naar `frontend/src/app/generated`

🤖 Generated with [Claude Code](https://claude.com/claude-code)