### PR TITLE
ci(dependabot): ignore majors that are blocked on planned migrations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,22 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Frontend majors are deferred to the coordinated Angular 17→21 +
+      # TypeScript 6 upgrade: they cannot pass CI until the Ampersand compiler
+      # emits `standalone: false` components, and the Angular dev-tooling must
+      # move in lockstep via `ng update`. Remove this block when that upgrade
+      # lands. NOTE: ignore rules also suppress dependabot security PRs for
+      # these updates; `npm audit` still reports them.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+      # 0.x packages whose breaking bumps count as "minor" and poison the
+      # grouped PR: zone.js 0.16 needs Angular 18+, @storybook/test-runner
+      # 0.17+ needs Storybook 8+. Patches remain allowed.
+      - dependency-name: "zone.js"
+        update-types: ["version-update:semver-minor"]
+      - dependency-name: "@storybook/test-runner"
+        update-types: ["version-update:semver-minor"]
 
   - package-ecosystem: "composer"
     directory: "/"
@@ -34,6 +50,14 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Breaking-API migrations that need dedicated backend work; the
+      # recurring PRs cannot be merged as-is. Remove per entry once the
+      # migration is planned.
+      - dependency-name: "slim/slim"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "phpoffice/phpspreadsheet"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Why

Dependabot keeps ~17 permanently-red major PRs open. They cannot pass CI:

- **Frontend npm majors** (Angular 17→21, TypeScript 6, Storybook 10, eslint stack, uuid 14, …) are blocked until the coordinated Angular 21 + TS 6 upgrade, which first needs the Ampersand compiler to emit `standalone: false` components (Angular 19 flips the default).
- **zone.js 0.14→0.16** and **@storybook/test-runner 0.16→0.24** are 0.x packages, so their breaking bumps count as *semver-minor* and poisoned the grouped frontend PR (#377): `npm ci` fails on `peer zone.js@"~0.14.0" from @angular/core@17.3.12`.
- **slim/slim 3→4** and **phpoffice/phpspreadsheet 1→5** are breaking-API backend migrations.

## What

Add `ignore` rules to `.github/dependabot.yml`:

- `/frontend` npm: all semver-major updates; semver-minor for `zone.js` and `@storybook/test-runner` (patches still flow).
- composer: semver-major for `slim/slim` and `phpoffice/phpspreadsheet`.

After this merges, the blocked major PRs can be closed and dependabot will not re-open them. The next weekly grouped frontend PR should then pass CI and auto-merge.

**Note:** ignore rules also suppress dependabot *security* PRs for the ignored updates; `npm audit` keeps reporting them. Remove the frontend block when the Angular 21 upgrade lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)