### PR TITLE
chore: upgrade bundled Ampersand compiler to v5.7.0 (activates OpenAPI publication)

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -51,7 +51,7 @@ jobs:
         docker run --rm \
           -v ${{ github.workspace }}:/workspace \
           --entrypoint /bin/ampersand \
-          ampersandtarski/ampersand:v5.6.3 \
+          ampersandtarski/ampersand:v5.7.0 \
           proto --frontend-version Angular --no-backend \
           /workspace/test/projects/hello-world/model/main.adl \
           --proto-dir /workspace/frontend/src/app/generated \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # To run generated prototypes we require a apache webserver with php
 # NOTE! Also check/update constraints in compiler-version.txt when updating the compiler
-ARG COMPILER_IMAGE=ampersandtarski/ampersand:v5.6.3
+ARG COMPILER_IMAGE=ampersandtarski/ampersand:v5.7.0
 FROM --platform=linux/amd64 ${COMPILER_IMAGE} AS compiler
 FROM --platform=linux/amd64 php:8.3-apache-bookworm AS framework
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,10 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
 
 Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format. In our case this is e.g. `-rc.1`, `-rc.2`.
 
+## v2.1.5 (2 July 2026)
+
+* Bundled Ampersand compiler upgraded to **v5.7.0**. This is the first released compiler that generates `generics/openapi.json` (an OpenAPI 3.0 description of the prototype's REST API) and supports `--[no-]production` / `--[no-]openapi`, which **activates the OpenAPI publication feature shipped in v2.1.1**: a development build now serves the spec at `GET /api/v1/openapi.json` and a Swagger UI at `GET /api/v1/docs`; a production build (compiler `--production`) generates no spec and sets `global.productionEnv = true`, so nothing is published. No framework code changes.
+
 ## v2.1.4 (1 July 2026)
 
 * Bundled Ampersand compiler upgraded to **v5.6.3**. From v5.6.2 the compiler makes `PrototypeContext.sessionActiveRoles` univalent (`[UNI]`), so a session activates at most one role — the backend counterpart of the single-active-role role switcher shipped in v2.1.3. It also brings convergent NavMenu role maintenance (removes an oscillation warning from every generated prototype) and a new IFC/EXPRESS/STEP reader. The minimum supported compiler version is raised to `>=5.6.2` accordingly.

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,5 +1,5 @@
 # To run generated prototypes we require a apache webserver with php
-ARG COMPILER_IMAGE=ampersandtarski/ampersand:v5.6.3
+ARG COMPILER_IMAGE=ampersandtarski/ampersand:v5.7.0
 FROM --platform=linux/amd64 ${COMPILER_IMAGE} AS compiler
 FROM --platform=linux/amd64 php:8.3-apache-bookworm AS framework
 

--- a/docs/guides/updating-and-releasing.md
+++ b/docs/guides/updating-and-releasing.md
@@ -37,7 +37,7 @@ The file `backend/generics/compiler-version.txt` contains the semantic version c
 
 The `Dockerfile` contains this construction:
 ```dockerfile
-ARG COMPILER_IMAGE=ampersandtarski/ampersand-compiler:20260617
+ARG COMPILER_IMAGE=ampersandtarski/ampersand:v5.7.0
 FROM --platform=linux/amd64 ${COMPILER_IMAGE} AS compiler
 
 <...>

--- a/docs/reference-material/prototype-framework.md
+++ b/docs/reference-material/prototype-framework.md
@@ -269,7 +269,7 @@ The file `backend/generics/compiler-version.txt` contains the semantic version c
 
 The `Dockerfile` contains this construction:
 ```dockerfile
-ARG COMPILER_IMAGE=ampersandtarski/ampersand-compiler:20260617
+ARG COMPILER_IMAGE=ampersandtarski/ampersand:v5.7.0
 FROM --platform=linux/amd64 ${COMPILER_IMAGE} AS compiler
 
 <...>


### PR DESCRIPTION
## What

Bumps the bundled Ampersand compiler from v5.6.3 to [v5.7.0](https://github.com/AmpersandTarski/Ampersand/releases/tag/v5.7.0) in `Dockerfile`, `dev.Dockerfile`, the frontend-tests CI job and the docs examples, plus a v2.1.5 changelog entry. No framework code changes.

v5.7.0 is the first released compiler that generates `generics/openapi.json` (OpenAPI 3.0 description of the prototype REST API) and supports `--[no-]production` / `--[no-]openapi`. This activates the OpenAPI publication feature shipped in framework v2.1.1: a development build now serves the spec at `GET /api/v1/openapi.json` and a Swagger UI at `GET /api/v1/docs`; a production build generates no spec and publishes nothing.

## Verification (end-to-end, local)

- `ampersandtarski/ampersand:v5.7.0` pulled from Docker Hub reports `--numeric-version` 5.7.0.
- Base image rebuilt for linux/amd64 from this branch; `box-filtered-dropdown` test project brought up on port 9080 and installed.
- `GET /api/v1/openapi.json` → 200, valid OpenAPI 3.0.3 (3 paths, 12 schemas); `GET /api/v1/docs` → 200, Swagger UI renders.
- App and `/api/v1/app/navbar` respond 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)