### PR TITLE
fix(installer): default defaultPop to true so install loads roles (fixes 403 on all interfaces)

### DIFF
--- a/backend/src/Ampersand/Controller/InstallerController.php
+++ b/backend/src/Ampersand/Controller/InstallerController.php
@@ -34,8 +34,12 @@ class InstallerController extends AbstractController
 
         $this->preventProductionMode(); // Reinstalling the whole application is not allowed in production environment
         
-        $defaultPop = filter_var($request->getQueryParam('defaultPop'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true;
-        $ignoreInvariantRules = filter_var($request->getQueryParam('ignoreInvariantRules'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? false;
+        // Coalesce the query param BEFORE filter_var. With FILTER_NULL_ON_FAILURE an absent/null input
+        // yields false (not null) in PHP 8.x, so a trailing `?? true` never applies the intended default.
+        // The old code therefore defaulted defaultPop to false, skipping the initial population (roles +
+        // ifcRoles) and leaving every interface inaccessible (403) after the documented install command.
+        $defaultPop = filter_var($request->getQueryParam('defaultPop') ?? true, FILTER_VALIDATE_BOOLEAN);
+        $ignoreInvariantRules = filter_var($request->getQueryParam('ignoreInvariantRules') ?? false, FILTER_VALIDATE_BOOLEAN);
 
         $this->app
             ->reinstall($defaultPop, $ignoreInvariantRules) // reinstall and initialize application


### PR DESCRIPTION
## Problem

The documented install command — `GET /api/v1/admin/installer?ignoreInvariantRules=true` — deterministically left **every** interface returning **403** (\"Unauthorized to access or interface does not exist\"), for any generated prototype.

## Root cause

`InstallerController::install()` parsed its boolean query params with:

```php
filter_var($param, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? true
```

In PHP 8.x, an absent/null input returns **`false`** (not `null`) from `filter_var`, so the trailing `?? true` never applies the intended default. `defaultPop` therefore silently defaulted to `false`, which skips `addInitialPopulation()` — the population that loads the roles + `ifcRoles` assignments.

With no roles in the database, no session gets an active role, and access control (which is role-based) denies every interface → 403 everywhere.

## Fix

Coalesce the query param **before** `filter_var`, so an absent param yields the intended default:

```php
$defaultPop = filter_var($request->getQueryParam('defaultPop') ?? true, FILTER_VALIDATE_BOOLEAN);
$ignoreInvariantRules = filter_var($request->getQueryParam('ignoreInvariantRules') ?? false, FILTER_VALIDATE_BOOLEAN);
```

## Verification

Live against a running prototype (compiler v5.7.0), with the exact documented command (no `defaultPop`):

| | Before | After |
|---|---|---|
| Role atoms loaded | 0 | 3 |
| ifcRoles links | 0 | 15 |
| Interface HTTP | 403 | 200 |

Empirically confirmed `filter_var(null, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)` returns `false` on PHP 8.3.31, and the fixed expression returns the intended defaults for absent / 'true' / 'false' / '1' / '0'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)