### PR TITLE
Release v2.4.1 — Ampersand compiler v5.8.0

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -51,7 +51,7 @@ jobs:
         docker run --rm \
           -v ${{ github.workspace }}:/workspace \
           --entrypoint /bin/ampersand \
-          ampersandtarski/ampersand:v5.7.0 \
+          ampersandtarski/ampersand:v5.8.0 \
           proto --frontend-version Angular --no-backend \
           /workspace/test/projects/hello-world/model/main.adl \
           --proto-dir /workspace/frontend/src/app/generated \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # To run generated prototypes we require a apache webserver with php
 # NOTE! Also check/update constraints in compiler-version.txt when updating the compiler
-ARG COMPILER_IMAGE=ampersandtarski/ampersand:v5.7.0
+ARG COMPILER_IMAGE=ampersandtarski/ampersand:v5.8.0
 FROM --platform=linux/amd64 ${COMPILER_IMAGE} AS compiler
 FROM --platform=linux/amd64 php:8.3-apache-bookworm AS framework
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,11 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
 
 Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format. In our case this is e.g. `-rc.1`, `-rc.2`.
 
-## v2.4.0 (unreleased)
+## v2.4.1 (7 July 2026)
+
+* Bundled Ampersand compiler upgraded to **v5.8.0**. It adds the transitive-reduction operator `%` (for an acyclic endorelation `r`, `r%` is the Hasse diagram, syntactic sugar for `r - (r;r+)`), replaces four unsound Kleene normalizer laws with sound unfoldings, and fixes two SQL-generation bugs around `r*` (the zero-step identity pairs were missing, and a `*/` inside a term could terminate a generated SQL comment early). No framework code changes; the supported compiler range in `backend/generics/compiler-version.txt` (`>=5.6.2 <6.0.0`) still holds. The image reference is bumped in `Dockerfile`, `dev.Dockerfile`, the frontend-tests workflow and the docs.
+
+## v2.4.0 (7 July 2026)
 
 * New feature: **per-interface transaction mode** — an interface runs as `Transactional` or `Direct`. Reference: `docs/reference-material/transactional-interfaces.md`.
   - **Transactional** (the new default): the interface buffers the user's edits on the client; nothing commits until the user presses **SAVE**. **CANCEL**, or navigating away ("Lose your edits?"), discards the buffer. SAVE is enabled only when the buffered edits leave no invariant rule violated.

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,5 +1,5 @@
 # To run generated prototypes we require a apache webserver with php
-ARG COMPILER_IMAGE=ampersandtarski/ampersand:v5.7.0
+ARG COMPILER_IMAGE=ampersandtarski/ampersand:v5.8.0
 FROM --platform=linux/amd64 ${COMPILER_IMAGE} AS compiler
 FROM --platform=linux/amd64 php:8.3-apache-bookworm AS framework
 

--- a/docs/guides/updating-and-releasing.md
+++ b/docs/guides/updating-and-releasing.md
@@ -37,7 +37,7 @@ The file `backend/generics/compiler-version.txt` contains the semantic version c
 
 The `Dockerfile` contains this construction:
 ```dockerfile
-ARG COMPILER_IMAGE=ampersandtarski/ampersand:v5.7.0
+ARG COMPILER_IMAGE=ampersandtarski/ampersand:v5.8.0
 FROM --platform=linux/amd64 ${COMPILER_IMAGE} AS compiler
 
 <...>

--- a/docs/reference-material/prototype-framework.md
+++ b/docs/reference-material/prototype-framework.md
@@ -271,7 +271,7 @@ The file `backend/generics/compiler-version.txt` contains the semantic version c
 
 The `Dockerfile` contains this construction:
 ```dockerfile
-ARG COMPILER_IMAGE=ampersandtarski/ampersand:v5.7.0
+ARG COMPILER_IMAGE=ampersandtarski/ampersand:v5.8.0
 FROM --platform=linux/amd64 ${COMPILER_IMAGE} AS compiler
 
 <...>


### PR DESCRIPTION
Patch release: bundled Ampersand compiler upgraded **v5.7.0 → v5.8.0**.

## What v5.8.0 brings
- New **transitive-reduction operator `%`** (Hasse diagram of an acyclic endorelation; sugar for `r - (r;r+)`).
- Four unsound Kleene normalizer laws replaced by sound unfoldings.
- SQL fixes for `r*`: the zero-step identity pairs were missing, and a `*/` inside a term could terminate a generated SQL comment early.

## Framework changes
- `COMPILER_IMAGE` bumped to `v5.8.0` in `Dockerfile`, `dev.Dockerfile`, `.github/workflows/frontend-tests.yml`, and the two docs examples.
- No framework code changes. Supported compiler range (`backend/generics/compiler-version.txt`, `>=5.6.2 <6.0.0`) still holds — no contract change.
- Also dates the `v2.4.0` changelog entry, which was still marked `(unreleased)`.

Note: the unrelated `release.yml` runner bump to `ubuntu-25.10` (not a valid GitHub-hosted runner label) is intentionally **not** part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)