### PR TITLE
Release v2.4.2 — CI release runner ubuntu-24.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   add-release-notes:
     name: Add release notes to artifacts
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
 
@@ -25,7 +25,7 @@ jobs:
 
   docker-hub:
     name: Build push image to DockerHub
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Docker meta
         id: meta
@@ -66,7 +66,7 @@ jobs:
   add-release-artifacts:
     name: Add artifacts to release
     needs: [build-framework-archive]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
 
@@ -104,7 +104,7 @@ jobs:
 
   build-framework-archive:
     name: Build framework archive
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout project contents 📡
         uses: actions/checkout@v7

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,10 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
 
 Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format. In our case this is e.g. `-rc.1`, `-rc.2`.
 
+## v2.4.2 (8 July 2026)
+
+* CI: the release workflow (`.github/workflows/release.yml`) moves from the soon-to-be-retired `ubuntu-22.04` runner to `ubuntu-24.04` (current LTS). The Ubuntu 22.04 runner images begin deprecation on 17 Sep 2026 and are unsupported from 17 Apr 2027, after which the build environment stops receiving security patches. No framework code changes; the runner builds the image but is not part of it, so this does not by itself change the shipped image's dependencies or its `php:8.3-apache-bookworm` base — those remain the actual vulnerability surface (kept current via Dependabot and by rebuilding the base image on each release).
+
 ## v2.4.1 (7 July 2026)
 
 * Bundled Ampersand compiler upgraded to **v5.8.0**. It adds the transitive-reduction operator `%` (for an acyclic endorelation `r`, `r%` is the Hasse diagram, syntactic sugar for `r - (r;r+)`), replaces four unsound Kleene normalizer laws with sound unfoldings, and fixes two SQL-generation bugs around `r*` (the zero-step identity pairs were missing, and a `*/` inside a term could terminate a generated SQL comment early). No framework code changes; the supported compiler range in `backend/generics/compiler-version.txt` (`>=5.6.2 <6.0.0`) still holds. The image reference is bumped in `Dockerfile`, `dev.Dockerfile`, the frontend-tests workflow and the docs.


### PR DESCRIPTION
Moves the four `release.yml` jobs from `ubuntu-22.04` to `ubuntu-24.04` (current LTS / `ubuntu-latest`).

Context: a working-tree edit had set them to `ubuntu-25.10`, which is **not** a valid GitHub-hosted runner label (available: `ubuntu-26.04` preview, `ubuntu-24.04`/`latest`, `ubuntu-22.04`) and would fail every release job. Split out from the v2.4.1 release so the compiler bump stays clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)