### PR TITLE
fix(box-table): render initially-empty tables; reflect FILTEREDDROPDOWN crud onto host attrs

### DIFF
--- a/frontend/cypress/e2e/box-filtered-dropdown.cy.ts
+++ b/frontend/cypress/e2e/box-filtered-dropdown.cy.ts
@@ -61,6 +61,28 @@ describe('BOX<FILTEREDDROPDOWN> regression', () => {
     cy.contains('Object is not readable').should('not.exist');
   });
 
+  it('reflects the effective crud onto the host attribute (matches dropdown gating)', () => {
+    // The component overrides this.crud from the setRelation metadata and reflects it to the host
+    // element. So for every atom the DOM `crud` attribute must agree with whether an interactive
+    // dropdown is rendered: a dropdown appears iff crud grants Update.
+    cy.get(DD).should('have.length.greaterThan', 0);
+    let editable = 0;
+    let readOnly = 0;
+    cy.get(DD)
+      .each(($atom) => {
+        const crud = $atom.attr('crud') || '';
+        const hasDropdown = $atom.find('p-dropdown').length > 0;
+        expect(hasDropdown, `crud="${crud}" (label="${$atom.attr('label')}")`).to.eq(
+          crud.includes('U'),
+        );
+        hasDropdown ? editable++ : readOnly++;
+      })
+      .then(() => {
+        expect(editable, 'some editable dropdowns exist').to.be.greaterThan(0);
+        expect(readOnly, 'some read-only dropdowns exist').to.be.greaterThan(0);
+      });
+  });
+
   TABS.forEach(({ tab, label, atoms }) => {
     describe(`${tab} tab`, () => {
       beforeEach(() => {

--- a/frontend/src/app/shared/atomic-components/atomic-object/atomic-object.component.ts
+++ b/frontend/src/app/shared/atomic-components/atomic-object/atomic-object.component.ts
@@ -2,6 +2,7 @@ import {
   booleanAttribute,
   Component,
   computed,
+  HostBinding,
   Input,
   OnDestroy,
   OnInit,
@@ -46,6 +47,21 @@ export class AtomicObjectComponent<I extends ObjectBase | ObjectBase[]>
   // Accept string from templates (e.g. mode="box-filtereddropdown") to avoid AOT enum binding error
   @Input() mode = '';
   @Input() strict = false;
+
+  // Reflect the effective crud/uni/tot onto the host element's attributes. For BOX<FILTEREDDROPDOWN>
+  // these are overridden from the setRelation metadata in ngOnInit; Angular does not write @Input
+  // property changes back to attributes, so without this the box-level defaults (e.g. crud="cRud")
+  // would linger in the DOM and mislead DevTools and e2e tests. No behaviour depends on these
+  // attributes — this only keeps the rendered DOM truthful.
+  @HostBinding('attr.crud') get reflectedCrud(): string {
+    return this.crud;
+  }
+  @HostBinding('attr.isuni') get reflectedIsUni(): '' | null {
+    return this.isUni ? '' : null;
+  }
+  @HostBinding('attr.istot') get reflectedIsTot(): '' | null {
+    return this.isTot ? '' : null;
+  }
 
   /**
    * @deprecated No longer has any effect. The component always renders a p-dropdown

--- a/frontend/src/app/shared/box-components/box-table/box-table.component.ts
+++ b/frontend/src/app/shared/box-components/box-table/box-table.component.ts
@@ -42,8 +42,22 @@ export class BoxTableComponent<
   @ContentChild(BoxTableRowTemplateDirective, { read: TemplateRef })
   rows?: TemplateRef<unknown>;
 
-  @ViewChild('primengTable', { static: true })
-  public primengTable: Table;
+  private _primengTable?: Table;
+
+  // #primengTable lives inside an *ngIf (hideBecauseEmpty), so a { static: true } query would be
+  // undefined in ngOnInit and throw ("Cannot set properties of undefined"). Use a setter query
+  // that configures the table whenever it appears — including after the *ngIf flips once data
+  // arrives — so an initially-empty BOX<TABLE> renders instead of crashing.
+  @ViewChild('primengTable')
+  set primengTable(table: Table | undefined) {
+    this._primengTable = table;
+    if (table) {
+      this.configurePrimengTable(table);
+    }
+  }
+  get primengTable(): Table {
+    return this._primengTable as Table;
+  }
 
   @Input({ transform: booleanAttribute })
   sortable = false;
@@ -59,20 +73,22 @@ export class BoxTableComponent<
 
   override ngOnInit(): void {
     super.ngOnInit();
+  }
 
-    this.primengTable.sortMode = 'multiple';
+  private configurePrimengTable(table: Table): void {
+    table.sortMode = 'multiple';
 
     // The defaultSortOrder is used when an unsorted column is sorted by user interaction
-    this.primengTable.defaultSortOrder = this.sortOrder === 'asc' ? 1 : -1;
+    table.defaultSortOrder = this.sortOrder === 'asc' ? 1 : -1;
 
     if (this.sortBy !== undefined) {
-      this.primengTable.multiSortMeta = [
+      table.multiSortMeta = [
         {
           field: this.sortBy,
           order: this.sortOrder === 'asc' ? 1 : -1,
         },
       ];
     }
-    this.primengTable.sortMultiple();
+    table.sortMultiple();
   }
 }


### PR DESCRIPTION
Two related frontend fixes, both surfaced while building an e2e regression test for `BOX<FILTEREDDROPDOWN>`.

## 1. `box-table`: initially-empty tables crash instead of rendering

`#primengTable` sits inside `*ngIf="!hideBecauseEmpty()"`, but the component queried it with `@ViewChild('primengTable', { static: true })` and configured sorting in `ngOnInit`. A **static** query resolves *before* structural directives, so for a table whose data loads asynchronously (empty at init) `primengTable` was `undefined` and `ngOnInit` threw:

```
TypeError: Cannot set properties of undefined (setting 'sortMode')
```

This broke **every `BOX<TABLE>` that starts empty** — the table (and its contents) never rendered.

**Fix:** a setter-based `@ViewChild` that configures the table whenever it appears (including after the `*ngIf` flips once data arrives).

## 2. `atomic-object`: stale `crud`/`isuni`/`istot` DOM attributes

For `BOX<FILTEREDDROPDOWN>` the component overrides `this.crud`/`isUni`/`isTot` from the `setRelation` metadata, but Angular does not write `@Input` property changes back to attributes — so the rendered DOM kept the box-level defaults (e.g. `crud="cRud"` everywhere) and misled DevTools and e2e tests. No behaviour depended on these attributes (they are not used as selectors anywhere), so this was cosmetic, but confusing.

**Fix:** `@HostBinding` getters reflect the effective `crud`/`isuni`/`istot` onto the host element.

## Verification

Rebuilt the base image + the box-filtered-dropdown test project and ran the e2e spec against the running prototype:

- **Before fix 1:** 0 atoms rendered, repeated `sortMode` crash.
- **After:** 192 atoms render, 0 crashes; `crud` attribute now reads `cRUd` on an editable dropdown and `cRud` on a read-only one (previously `cRud` everywhere).
- **e2e:** all 7 tests pass, including a new assertion that the reflected `crud` attribute agrees with the dropdown gating for every atom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)