### PR TITLE
test(e2e): cover deeply-nested FILTEREDDROPDOWN (issue #266)

### DIFF
--- a/frontend/cypress/e2e/box-filtered-dropdown.cy.ts
+++ b/frontend/cypress/e2e/box-filtered-dropdown.cy.ts
@@ -124,4 +124,33 @@ describe('BOX<FILTEREDDROPDOWN> regression', () => {
         );
       });
   });
+
+  describe('deep nesting (issue #266)', () => {
+    // The NestedFilteredDropdown interface renders a FILTEREDDROPDOWN three boxes deep:
+    // FORM > BOX(I /\ eligible;eligible~, an expression-driven box) > TABS > FILTEREDDROPDOWN.
+    beforeEach(() => {
+      cy.visit(`${BASE}/nestedfiltereddropdown`);
+      cy.get(DD, { timeout: 15000 }).should('have.length.greaterThan', 0);
+    });
+
+    it('renders the FILTEREDDROPDOWN nested inside the intermediate boxes', () => {
+      cy.contains('label.box-form-label', 'nivo 1').should('be.visible');
+      cy.contains('label.box-form-label', 'nivo 2').should('be.visible');
+      // The deepest atom is an editable FILTEREDDROPDOWN (setRelation projectMember CRUD).
+      cy.get(DD).first().find('p-dropdown').should('exist');
+    });
+
+    it('filters the nested dropdown to selectFrom (eligible employees)', () => {
+      cy.get(DD).first().find('p-dropdown').click();
+      cy.get('.p-dropdown-panel .p-dropdown-item', { timeout: 8000 })
+        .should('have.length.greaterThan', 0)
+        .then(($items) => {
+          [...$items]
+            .map((el) => el.textContent?.trim() || '')
+            .forEach((l) => {
+              expect(ALL_EMPLOYEES, `option "${l}" is a known employee`).to.include(l);
+            });
+        });
+    });
+  });
 });

--- a/test/projects/box-filtered-dropdown/model/main.adl
+++ b/test/projects/box-filtered-dropdown/model/main.adl
@@ -412,9 +412,24 @@ INTERFACE BoxFilteredDropdownErrors LABEL "Box-Filtered-Dropdown-errors" : "_SES
     --       ]
     --   , "5. Assign an employee (cRud)" : I BOX<FILTEREDDROPDOWN> -- relation and selectFrom of different type, swapped
     --       [ "setRelation"   : eligible cRud
-    --       , "selectFrom"  : projectLocation 
+    --       , "selectFrom"  : projectLocation
     --       ]
       ]
+  ]
+
+-- Regression for issue #266: a FILTEREDDROPDOWN nested deep inside other boxes,
+-- including an expression-driven intermediate box (I /\ eligible;eligible~).
+-- FORM > BOX(expression) > TABS > FILTEREDDROPDOWN.
+INTERFACE NestedFilteredDropdown LABEL "Nested Filtered-Dropdown" : "_SESSION";V[SESSION*Project] cRud BOX<FORM>
+  [ "Project ID" : I cRud
+  , "nivo 1" : I /\ eligible;eligible~ cRud BOX
+    [ "nivo 2" : I[Project] cRud BOX<TABS>
+      [ "nivo 3" : I[Project] cRud BOX<FILTEREDDROPDOWN>
+        [ "selectFrom"  : eligible
+        , "setRelation" : projectMember CRUD
+        ]
+      ]
+    ]
   ]
 
 ENDCONTEXT


### PR DESCRIPTION
Adds regression coverage for a `BOX<FILTEREDDROPDOWN>` nested deep inside other boxes — the case behind issue #266.

## Context

The stale branch `issues/266/box-filtered-dropdown/nesting` (Oct 2025) prototyped nesting support with a dedicated `BoxFilteredDropdownComponent` and heuristic path parsing. `main` has since solved nested-path resolution the other way (evolved `interfaces-json.service.ts` walking sub-paths, with the `atomic-object` `mode="box-filtereddropdown"` renderer). So the branch's code is superseded — but its intent (deep nesting) deserved a regression test.

## What this adds

- **Model**: a `NestedFilteredDropdown` interface in the box-filtered-dropdown test project that renders a FILTEREDDROPDOWN three boxes deep:
  `FORM > BOX(I /\ eligible;eligible~) > TABS > FILTEREDDROPDOWN`.
  The intermediate `I /\ eligible;eligible~` is an **expression-driven** box — the shape the existing spec did not exercise (basic `TABS > FORM > TABLE > FILTEREDDROPDOWN` nesting was already covered).
- **Spec**: two e2e assertions — the nested dropdown renders inside the `nivo 1`/`nivo 2` boxes, and it filters its options to `selectFrom` (eligible employees).

## Verification

Rebuilt the prototype with the new interface and ran the spec against it:

- The nested FILTEREDDROPDOWN renders (3 atoms), `crud` attribute reads `CRUD`, dropdown interactive.
- **All 9 spec tests pass** (7 existing + 2 new).

Confirms `main` already supports expression-driven deep nesting; no framework change needed. The `deep.adl`/`tiny.adl` fixtures from the old branch are not adopted — `tiny.adl` duplicates an existing tab, and `deep.adl`'s coverage is captured here with `main`'s own concepts (no second deployment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)