### PR TITLE
fix(ci): keep the regression loop to build cases only

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,11 +18,20 @@ jobs:
     - name: Build
       run: docker build --tag ${DOCKER_AMPERSAND_IMAGE}:local .
 
+    # Every case under test/regression/ is a build case: the Dockerfile here compiles the
+    # case's script.adl and builds the frontend. A directory without a script.adl is not a
+    # build case; it is reported and skipped instead of failing the compiler on a missing
+    # file. Runtime specs live with their project (test/projects/<project>/e2e/).
     - name: Tests
-      run: >
-        cd test/regression &&
+      run: |
+        cd test/regression
         for d in */ ; do
-          echo "$d" && docker buildx build --build-context test=$d .
+          if [ ! -f "${d}script.adl" ]; then
+            echo "::warning::skipping ${d}: no script.adl, so it is not a build case"
+            continue
+          fi
+          echo "building ${d}"
+          docker buildx build --build-context test="$d" .
         done
 
   static-analyzer:

--- a/test/projects/navmenu-grouping/e2e/test.mjs
+++ b/test/projects/navmenu-grouping/e2e/test.mjs
@@ -3,7 +3,7 @@
  * expression type + idempotent (re)install of the nav menu population.
  *
  * Prerequisites: dev stack running (`docker compose up -d` in the repo root).
- * Run: node test/regression/issue-406/test.mjs
+ * Run: node test/projects/navmenu-grouping/e2e/test.mjs
  *
  * The script:
  * 1. compiles test/projects/navmenu-grouping into the backend (no frontend build);
@@ -19,7 +19,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
-const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
 const projectYaml = resolve(repoRoot, 'backend/config/project.yaml');
 const baseUrl = process.env.PROTOTYPE_URL ?? 'http://localhost';
 
@@ -39,7 +39,7 @@ function setSettings(settings) {
   const lines = Object.entries(settings)
     .map(([k, v]) => `  ${k}: ${v}`)
     .join('\n');
-  const content = `# TEMPORARY test config, written by test/regression/issue-406/test.mjs\nsettings:\n${lines}\n`;
+  const content = `# TEMPORARY test config, written by test/projects/navmenu-grouping/e2e/test.mjs\nsettings:\n${lines}\n`;
   writeFileSync(projectYaml, content);
 
   // The macOS bind mount propagates file changes with a delay; wait until the

--- a/test/regression/README.md
+++ b/test/regression/README.md
@@ -1,0 +1,40 @@
+# Build regression cases
+
+Each subdirectory here is a **build case**: a minimal `script.adl` that the `Dockerfile` in
+this directory compiles into the base image and builds an Angular frontend from. The CI job
+`regression-tests` (`.github/workflows/continuous-integration.yml`) builds every case on
+every pull request.
+
+**Guards:** that a model construct still compiles and that the generated frontend still
+builds. It does not observe runtime behaviour — a case that compiles and builds is green,
+however the prototype behaves in a browser.
+
+## Adding a build case
+
+```
+test/regression/<case>/script.adl
+```
+
+That is the whole contract: a directory with a `script.adl` in it. The CI loop skips (and
+reports) directories without one, so a case that is not a build case cannot silently turn
+the pipeline red.
+
+Run one case locally:
+
+```bash
+docker build --tag ampersandtarski/prototype-framework:local .   # from the repo root
+cd test/regression && docker buildx build --build-context test=<case>/ .
+```
+
+## Runtime tests belong with their project
+
+Tests that observe a **running** prototype (API calls, browser assertions) do not belong
+here: they need a stack, not a build. They live with the model they exercise:
+
+```
+test/projects/<project>/e2e/
+```
+
+for example `test/projects/navmenu-grouping/e2e/test.mjs`. See
+[issue #402](https://github.com/AmpersandTarski/prototype/issues/402) for the runtime
+regression pipeline that ties these together.


### PR DESCRIPTION
CI has been red on every pull request since 61e76f51 (2026-07-14) — spanning the v2.5.0, v2.5.1 and v2.5.2 releases.

## Diagnosis

`test/regression/` is a **build matrix**: the CI loop builds every subdirectory with the `Dockerfile` there, which compiles that case's `script.adl`.

#406 added `test/regression/issue-406/test.mjs` — a *runtime* script that drives a live dev stack (`docker exec prototype`, HTTP against `localhost`) and has no `script.adl`. The loop built it anyway, so the compiler exited 10:

```
command line argument error:
ERROR: process "/bin/sh -c ampersand proto --no-frontend /usr/local/project/script.adl ..." exit code: 10
```

Two kinds of test shared one directory, and the loop assumed every directory was a build case.

## Change

- The runtime spec moves to `test/projects/navmenu-grouping/e2e/test.mjs` — the location that the plan in #402 already names for specs — with its repo-root path adjusted to the new depth.
- The loop builds only directories carrying a `script.adl`, and reports the ones it skips (`::warning::`), so a stray directory cannot turn the pipeline red again.
- `test/regression/README.md` states the contract: build cases here, runtime specs with their project.

## Verification

The loop runs only on pull requests, so **this PR is the gate**: the `Regression tests` job going green is the proof. The loop's logic was checked locally against a case with and without a `script.adl`.

Refs #402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)