### PR TITLE
feat(test): runtime regression runner for the test projects (#402 phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,18 @@
 2. Genereer en bouw: `./generate.sh <test-project-map> <entry-file.adl>` (bijv. `./generate.sh box-filtered-dropdown main.adl`). Geldige `<test-project-map>` = een submap van `test/projects/` (default: `hello-world`).
 3. Test in browser op `http://localhost` (controleer console op JS errors)
 
+### Merge-gate: `test/run-regression.sh` (standaard)
+
+Verifieer vóór elke merge met de runner; noem in het merge-rapport welke projecten je draaide en hun verdict.
+
+- `test/run-regression.sh <project>` — één project: eigen stack (poort 9400), model compileren, installeren, spec draaien, afbreken. Exitcode = verdict.
+- `test/run-regression.sh all` — alle projecten + contributierapport (verdict, duur, en wat elk project bewaakt).
+- `test/run-regression.sh --list` — wat elk project bewaakt (uit de `**Guards:**`-regel van zijn README).
+
+Raakt je wijziging gedrag dat nog geen project bewaakt? Voeg dan een project of spec toe (`test/projects/<p>/e2e/`) — de reproductie die de bug aantoonde wordt de regressie die de fix bewaakt. Zie issue #402; browser-specs zijn Playwright. Runs serialiseren zichzelf met een lock (`flock` bestaat niet op macOS, dus de runner gebruikt een mkdir-lock).
+
+De runner compileert het model in je werkkopie: ná een run staan in `backend/generics/` en `html/` de bestanden van het laatst gedraaide project (allebei gitignored). Draai `./generate.sh <project>` om je dev-stack terug te zetten op het project waaraan je werkt.
+
 ## 3. Base Image Bouwen (Voor linux/amd64)
 Het base image (`ampersandtarski/prototype-framework:local`) wordt gebruikt in `FROM` statements van alle test- en klantprojecten.
 **ALTIJD bouwen voor `linux/amd64`**, ook op Apple Silicon:

--- a/test/projects/ifc45/regression.conf
+++ b/test/projects/ifc45/regression.conf
@@ -1,0 +1,2 @@
+# Entry model of this project (default: model/main.adl)
+entry=model/app.adl

--- a/test/projects/navmenu-grouping/README.md
+++ b/test/projects/navmenu-grouping/README.md
@@ -1,4 +1,16 @@
-# navmenu-grouping
+# navmenu-grouping — regression vehicle
+
+**Guards:** navigation-menu grouping by interface expression type: task screens stay
+top-level, list interfaces move under one group item whose label is configurable, and
+reinstalling leaves the menu population identical (no stale or duplicate items).
+
+**Origin:** [issue #406](https://github.com/AmpersandTarski/prototype/issues/406) / v2.5.0.
+
+**Run:** `test/run-regression.sh navmenu-grouping`
+
+**Green means:** every assertion in `e2e/test.mjs` passes — the three settings cases
+(`none`, `byType`, custom label) produce the menu in the table below, and a second
+installer run yields the identical population.
 
 Regression vehicle for [issue #406](https://github.com/AmpersandTarski/prototype/issues/406):
 default navigation-menu grouping by interface expression type.

--- a/test/projects/navmenu-grouping/e2e/test.mjs
+++ b/test/projects/navmenu-grouping/e2e/test.mjs
@@ -22,6 +22,8 @@ import { dirname, resolve } from 'node:path';
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../../..');
 const projectYaml = resolve(repoRoot, 'backend/config/project.yaml');
 const baseUrl = process.env.PROTOTYPE_URL ?? 'http://localhost';
+// test/run-regression.sh runs this spec against its own stack; without it, the dev stack.
+const container = process.env.PROTOTYPE_CONTAINER ?? 'prototype';
 
 const originalYaml = readFileSync(projectYaml, 'utf8');
 
@@ -47,7 +49,7 @@ function setSettings(settings) {
   const deadline = Date.now() + 15000;
   for (;;) {
     const inContainer = execSync(
-      'docker exec prototype cat /var/www/backend/config/project.yaml',
+      `docker exec ${container} cat /var/www/backend/config/project.yaml`,
       { encoding: 'utf8' },
     );
     if (inContainer === content) {
@@ -99,7 +101,7 @@ const LISTS = [
 try {
   console.log('▶ Compiling navmenu-grouping model into backend ...');
   execSync(
-    'docker exec prototype sh -c "ampersand proto --no-frontend ' +
+    `docker exec ${container} sh -c "ampersand proto --no-frontend ` +
       '/var/www/test/projects/navmenu-grouping/model/main.adl ' +
       '--proto-dir /var/www/backend --crud-defaults cRud"',
     { stdio: 'inherit' },

--- a/test/projects/project-administration/regression.conf
+++ b/test/projects/project-administration/regression.conf
@@ -1,0 +1,2 @@
+# Entry model of this project (default: model/main.adl)
+entry=model/ProjectAdministration.adl

--- a/test/projects/propbutton-unit-test/regression.conf
+++ b/test/projects/propbutton-unit-test/regression.conf
@@ -1,0 +1,2 @@
+# Entry model of this project (default: model/main.adl)
+entry=model/PropButtonTest.adl

--- a/test/projects/search-guard/README.md
+++ b/test/projects/search-guard/README.md
@@ -1,0 +1,23 @@
+# search-guard — regression vehicle
+
+**Guards:** that the full-text search module returns only atoms the session may read. A
+session without any role must not receive stored values through `GET /api/v1/search`, and a
+session that holds the reading role must still find them.
+
+**Origin:** v2.5.2. Until then the module returned every matching atom together with the
+value that matched, without checking read rights: an anonymous, not-logged-in session
+received the stored values themselves. The module already computed, per result, the
+interfaces to open the atom in (`_ifcs_`) and returned results even when that list was empty.
+
+**Run:** `test/run-regression.sh search-guard` (or `test/search-guard/test.sh`, which runs
+the two phases against a stack of its own; see `test/search-guard/README.md`)
+
+**Green means:** searching "Vertrouwelijk" returns nothing for an anonymous session, and
+returns dossier `d1` carrying interface `Dossiers` for a session with the Caseworker role.
+
+## Model
+
+`dossierNote[Dossier*Note]` is deliberately **non-univalent**, so the compiler stores it in
+its own binary table: the search module reads binary tables (it does not currently reach
+values in a concept's broad table). `Dossier` is readable through `INTERFACE Dossiers FOR
+Caseworker` only, so an anonymous session has no interface to open it in.

--- a/test/projects/session-gc-login/README.md
+++ b/test/projects/session-gc-login/README.md
@@ -1,0 +1,26 @@
+# session-gc-login — regression vehicle
+
+**Guards:** that login and logout keep working while the framework garbage collects expired
+sessions. It exercises the paths where session atoms are created and deleted: the SIAM
+login/logout mechanism (ExecEngine `InsPair sessionAccount` / `DelAtom SESSION`), the
+framework's own session renewal (`AmpersandApp::resetSession`, which commits the old atom's
+deletion separately), and both under concurrent requests.
+
+**Origin:** v2.5.2. The session garbage collector calls `resetSession`, which login also
+uses (session renewal per OWASP), so the changed transaction boundaries had to be shown not
+to break logging in or out.
+
+**Run:** `test/session-gc/login-test.sh all` — see `test/session-gc/README.md` for the setup
+(the model needs `session.loginEnabled: true` and a short `session.expirationTime`).
+
+**Green means:** all phases PASS: login through the Login interface, logout (the session
+deletes itself), framework login through `/admin/test/login` (session id renewed, old atom
+gone), garbage collection of an expired logged-in session, and a concurrent mix of login,
+new and returning sessions.
+
+## Model
+
+A minimal SIAM-style model: `sessionIsAnon`/`sessionIsUser` properties, U/PW login and the
+`DelAtom SESSION` logout rule, copied from `SIAM_Basics.adl` and `SIAM_LoginWithUPW.adl`
+without navigation and password hashing (both orthogonal to session/transaction behaviour).
+`Password` is `ALPHANUMERIC` here on purpose: hashing is not what this vehicle guards.

--- a/test/run-regression.sh
+++ b/test/run-regression.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+#
+# Runtime regression runner (issue #402, phase 1).
+#
+#   test/run-regression.sh <project>   # verify one project in test/projects/
+#   test/run-regression.sh all         # verify every project, then print the report
+#   test/run-regression.sh --list      # show what each project guards
+#
+# Per project it brings up an isolated stack, compiles the project's model into it,
+# installs the application and runs the project's spec (test/projects/<project>/e2e/),
+# then tears the stack down. The exit code is the verdict.
+#
+# A project without a spec is reported as "no spec" and does not count as verified:
+# bringing a stack up only shows that the model compiles and installs.
+#
+set -uo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+PROJECTS_DIR="$REPO_ROOT/test/projects"
+COMPOSE_FILE="$REPO_ROOT/test/runtime-stack.compose.yaml"
+REG_PORT="${REG_PORT:-9400}"
+BASE_URL="http://localhost:${REG_PORT}"
+
+# The stack claims a port, container names and the working copy's generated files, so two
+# runs cannot overlap. flock(1) is not available on macOS, so we lock with mkdir, which is
+# atomic on every POSIX filesystem.
+LOCK_DIR="${TMPDIR:-/tmp}/ampersand-regression.lock.d"
+
+log()  { printf '%s\n' "$*"; }
+step() { printf '  → %s\n' "$*"; }
+
+acquire_lock() {
+  if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    log "Another regression run holds the lock ($LOCK_DIR)."
+    log "Wait for it to finish, or remove the directory if no run is active."
+    exit 3
+  fi
+  trap 'rm -rf "$LOCK_DIR"' EXIT
+}
+
+# The entry model of a project. Defaults to model/main.adl; a project whose entry file has
+# another name states it in regression.conf (e.g. ENTRY=model/app.adl).
+entry_model() {
+  local project="$1" entry="model/main.adl"
+  local conf="$PROJECTS_DIR/$project/regression.conf"
+  [ -f "$conf" ] && . "$conf"
+  printf '%s' "$entry"
+}
+
+# What a project guards, taken from the "Guards:" line of its README (phase 0 format).
+guards_of() {
+  local readme="$PROJECTS_DIR/$1/README.md"
+  [ -f "$readme" ] || { printf 'no README — what does this project guard?'; return; }
+  local line
+  line=$(grep -m1 -i '^\*\*Guards:\*\*\|^- \*\*Guards:\*\*\|^Guards:' "$readme" 2>/dev/null \
+         | sed -E 's/^-? ?\*\*Guards:\*\*[[:space:]]*//I; s/^Guards:[[:space:]]*//I')
+  printf '%s' "${line:-no Guards: line in README}"
+}
+
+# --wait blocks until the database reports healthy (see the healthcheck in the compose file),
+# so the application is never installed against a database that is still starting.
+stack_up() {
+  local project="$1"
+  REG_STACK="reg-$project" REG_PORT="$REG_PORT" \
+    docker compose -f "$COMPOSE_FILE" -p "reg-$project" up -d --build --wait >/dev/null 2>&1
+}
+
+stack_down() {
+  local project="$1"
+  REG_STACK="reg-$project" REG_PORT="$REG_PORT" \
+    docker compose -f "$COMPOSE_FILE" -p "reg-$project" down -v >/dev/null 2>&1
+}
+
+# Wait until Apache answers. Any response will do (the application is not installed yet),
+# so do not request the installer here: that would install before the model is compiled.
+wait_for_web() {
+  local deadline=$((SECONDS + 90))
+  while [ $SECONDS -lt $deadline ]; do
+    curl -s -o /dev/null "$BASE_URL/" && return 0
+    sleep 2
+  done
+  return 1
+}
+
+# Verify one project. Prints its own progress; returns 0 = pass, 1 = fail, 2 = no spec.
+run_project() {
+  local project="$1"
+  local dir="$PROJECTS_DIR/$project"
+  local model; model=$(entry_model "$project")
+
+  [ -d "$dir" ] || { log "unknown project: $project"; return 1; }
+  [ -f "$dir/$model" ] || { log "no entry model $model in $project (see regression.conf)"; return 1; }
+
+  step "stack up (port $REG_PORT)"
+  stack_up "$project" || { log "  stack failed to start"; stack_down "$project"; return 1; }
+  # shellcheck disable=SC2064
+  trap "stack_down '$project'; rm -rf '$LOCK_DIR'" EXIT
+
+  wait_for_web || { log "  web server did not come up"; stack_down "$project"; return 1; }
+
+  step "dependencies"
+  docker exec "reg-$project-prototype" sh -c \
+    '[ -f /var/www/backend/lib/autoload.php ] || (cd /var/www && composer install --no-interaction)' \
+    >/dev/null 2>&1
+
+  step "compile $model"
+  if ! docker exec "reg-$project-prototype" sh -c \
+      "ampersand proto --no-frontend /var/www/test/projects/$project/$model \
+       --proto-dir /var/www/backend --crud-defaults cRud" >/dev/null 2>&1; then
+    log "  model did not compile"
+    stack_down "$project"
+    return 1
+  fi
+
+  # Expose the API (the front controller); specs that need the built frontend build it themselves.
+  docker exec "reg-$project-prototype" sh -c \
+    'mkdir -p /var/www/html && cp -r /var/www/backend/public/. /var/www/html/' >/dev/null 2>&1
+
+  step "install application"
+  local installer_out curl_rc
+  # -sS keeps curl quiet but reports transport errors (e.g. connection refused) on stderr,
+  # so a failure states its cause instead of an empty body.
+  installer_out=$(curl -sS -f "$BASE_URL/api/v1/admin/installer?ignoreInvariantRules=true" 2>&1)
+  curl_rc=$?
+  if [ $curl_rc -ne 0 ]; then
+    log "  installer failed (curl exit $curl_rc):"
+    printf '%s\n' "${installer_out:-(no output)}" | head -20 | sed 's/^/    /'
+    stack_down "$project"
+    return 1
+  fi
+
+  local rc=2 # no spec, until we find one
+  if compgen -G "$dir/e2e/*.spec.ts" >/dev/null; then
+    step "spec (playwright)"
+    ( cd "$REPO_ROOT/test" && PROTOTYPE_URL="$BASE_URL" PROTOTYPE_CONTAINER="reg-$project-prototype" \
+        npx playwright test "$dir/e2e" ) && rc=0 || rc=1
+  elif compgen -G "$dir/e2e/*.mjs" >/dev/null; then
+    step "spec (node)"
+    rc=0
+    for spec in "$dir"/e2e/*.mjs; do
+      PROTOTYPE_URL="$BASE_URL" PROTOTYPE_CONTAINER="reg-$project-prototype" \
+        node "$spec" || rc=1
+    done
+  fi
+
+  stack_down "$project"
+  trap 'rm -rf "$LOCK_DIR"' EXIT
+  return $rc
+}
+
+verdict_text() {
+  case "$1" in
+    0) printf 'PASS' ;;
+    2) printf 'no spec' ;;
+    *) printf 'FAIL' ;;
+  esac
+}
+
+case "${1:-}" in
+  --list)
+    log "What each project guards:"
+    for dir in "$PROJECTS_DIR"/*/; do
+      p=$(basename "$dir")
+      printf '  %-24s %s\n' "$p" "$(guards_of "$p")"
+    done
+    ;;
+
+  all)
+    acquire_lock
+    declare -a names=() verdicts=() times=()
+    for dir in "$PROJECTS_DIR"/*/; do
+      p=$(basename "$dir")
+      log ""
+      log "=== $p ==="
+      start=$SECONDS
+      run_project "$p"; rc=$?
+      names+=("$p"); verdicts+=("$rc"); times+=("$((SECONDS - start))")
+    done
+
+    # Contribution report: what did this run guard, and what did it cost?
+    log ""
+    log "================ regression report ================"
+    printf '%-24s %-8s %6s  %s\n' "project" "verdict" "sec" "guards"
+    fails=0; nospec=0
+    for i in "${!names[@]}"; do
+      printf '%-24s %-8s %6s  %s\n' \
+        "${names[$i]}" "$(verdict_text "${verdicts[$i]}")" "${times[$i]}" "$(guards_of "${names[$i]}")"
+      [ "${verdicts[$i]}" = "1" ] && fails=$((fails + 1))
+      [ "${verdicts[$i]}" = "2" ] && nospec=$((nospec + 1))
+    done
+    log "---------------------------------------------------"
+    log "${#names[@]} projects, $fails failed, $nospec without a spec (not verified)"
+    [ "$fails" -eq 0 ] || exit 1
+    ;;
+
+  ""|-h|--help)
+    sed -n '2,16p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+    exit 2
+    ;;
+
+  *)
+    acquire_lock
+    log "=== $1 ==="
+    run_project "$1"; rc=$?
+    log "verdict: $(verdict_text "$rc") — guards: $(guards_of "$1")"
+    [ "$rc" = "1" ] && exit 1
+    exit 0
+    ;;
+esac

--- a/test/runtime-stack.compose.yaml
+++ b/test/runtime-stack.compose.yaml
@@ -1,0 +1,58 @@
+# Parameterised runtime stack for test/run-regression.sh.
+#
+# One stack per regression run. The runner serialises runs with a lock, so a single
+# fixed port is enough; REG_PORT overrides it when you want to keep a stack up for
+# debugging. REG_STACK scopes the container names, so a leftover stack is recognisable
+# (`docker ps | grep reg-`).
+volumes:
+  db-data:
+
+networks:
+  reg:
+
+services:
+  prototype:
+    container_name: ${REG_STACK:-reg}-prototype
+    platform: linux/amd64
+    build:
+      context: ..
+      dockerfile: dev.Dockerfile
+    depends_on:
+      prototype-db:
+        condition: service_healthy
+    ports:
+      - "${REG_PORT:-9400}:80"
+    volumes:
+      - ..:/var/www # the runner compiles the project's model into this working copy
+    networks:
+      - reg
+    environment:
+      - AMPERSAND_DEBUG_MODE=true
+      - AMPERSAND_DBHOST=${REG_STACK:-reg}-db
+      - AMPERSAND_DBUSER=ampersand
+      - AMPERSAND_DBPASS=ampersand
+      - AMPERSAND_SERVER_URL=http://localhost:${REG_PORT:-9400}
+
+  prototype-db:
+    container_name: ${REG_STACK:-reg}-db
+    image: mariadb:10.6
+    command: ["--lower-case-table-names=1", "--sql-mode=ANSI,TRADITIONAL"]
+    environment:
+      - MYSQL_ROOT_PASSWORD=ampersand
+      - MYSQL_USER=ampersand
+      - MYSQL_PASSWORD=ampersand
+    volumes:
+      - db-data:/var/lib/mysql
+      - ../db-init-scripts:/docker-entrypoint-initdb.d
+    networks:
+      - reg
+    # Ping over TCP (-h 127.0.0.1), not over the socket. While the entrypoint initialises a
+    # fresh volume it runs a temporary server that answers on the socket but not on the
+    # network — measured: socket answers at 3s, TCP at 5s. The prototype connects over the
+    # network, so only a TCP answer means "usable". Waiting on the socket lets the installer
+    # hit a database that is still restarting, which surfaces as a 500.
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uampersand", "-pampersand", "--silent"]
+      interval: 2s
+      timeout: 5s
+      retries: 45


### PR DESCRIPTION
Phase 1 of #402: one command that re-verifies a test project from a clean checkout.

```
test/run-regression.sh <project>   # isolated stack → compile model → install → spec → tear down
test/run-regression.sh all         # every project + contribution report
test/run-regression.sh --list      # what each project guards
```

## The contribution report

`all` ends with the report the plan asks for — verdict, cost, and what each project guards (from the `**Guards:**` line of its README). It reports the coverage gap instead of reporting green:

```
project                  verdict     sec  guards
any-role                 no spec      11  the "Any"-role access model: an interface without a FOR-clause is
navmenu-grouping         PASS         15  navigation-menu grouping by interface expression type: task screens stay
ifc45                    FAIL         32  framework behaviour at model scale: a large concept hierarchy
project-administration   FAIL         10  no README — what does this project guard?
...
13 projects, 2 failed, 10 without a spec (not verified)
```

A project without a spec is **not** verified: bringing a stack up only shows that the model compiles and installs.

## Two findings, surfaced by the first full run

Pre-existing defects, not regressions of this change. Each gets its own issue:

- **project-administration** does not compile with compiler v5.9.3 — old relation syntax (`projectName :: Project * ProjectName`) inside a `CONCEPT` block.
- **ifc45** compiles but fails to install: `MYSQL err1118: Row size too large` — a broad table beyond MySQL's 65535-byte row limit. That is exactly what this vehicle exists to guard ("framework behaviour at model scale").

## Two details that cost time

- **Readiness.** Waiting for the database with `mysqladmin ping` returns too early: while the entrypoint initialises a fresh volume it runs a temporary server that answers on the socket but not over TCP (measured: socket at 3s, TCP at 5s). The prototype connects over TCP, so the installer hit a database that was still restarting → 500. The database now has a healthcheck that pings over TCP; the runner uses `up --wait`.
- **Locking.** `flock(1)` does not exist on macOS, so runs serialise with an `mkdir` lock (atomic on any POSIX filesystem).

## Also in this PR

- READMEs in the phase-0 format for `search-guard`, `session-gc-login` (both added with v2.5.2) and `navmenu-grouping`.
- `regression.conf` for the three projects whose entry model is not `model/main.adl`.
- CLAUDE.md names the runner as the default merge-gate.
- The runtime spec of #406 now runs through the runner (`PROTOTYPE_CONTAINER`/`PROTOTYPE_URL`), against the runner's own stack instead of the dev stack.

Refs #402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)