### PR TITLE
fix: hide "New" and "+" buttons for SESSION/ONE concepts in BOX<FORM>

### DIFF
--- a/frontend/src/app/shared/box-components/box-form/box-form.component.html
+++ b/frontend/src/app/shared/box-components/box-form/box-form.component.html
@@ -1,7 +1,8 @@
 <ng-container *ngIf="!hideBecauseEmpty()">
     <div class="box-title" *ngIf="title">{{ title }}</div>
 
-    <div *ngIf="canCreate() && isEmpty()">
+    <!-- SESSION and ONE are singleton concepts — no "new" instance can be created from the UI -->
+    <div *ngIf="canCreate() && isEmpty() && tgtResourceType !== 'SESSION' && tgtResourceType !== 'ONE'">
         <p-button [rounded]="true" size="small" (click)="createItem()">
             New {{ tgtResourceType }}
         </p-button>
@@ -16,7 +17,7 @@
                 [resource]="item"
             ></app-ifcs-dropdown>
             <span
-                *ngIf="canCreate()"
+                *ngIf="canCreate() && tgtResourceType !== 'SESSION' && tgtResourceType !== 'ONE'"
                 class="pi pi-fw pi-plus"
                 pTooltip="Add"
                 tooltipPosition="left"


### PR DESCRIPTION
## Problem

`BOX<FORM>` showed a "New {concept}" button (when the list was empty) and a "+" add button (on each existing item) for SESSION and ONE concepts. These are singleton concepts — only one instance ever exists — so offering to create new instances is misleading and non-functional.

## Fix

Guard both buttons with `tgtResourceType !== "SESSION" && tgtResourceType !== "ONE"`.