### PR TITLE
fix: ifcs-dropdown builds incorrect route for SESSION/ONE-scope interfaces

### DIFF
--- a/frontend/src/app/shared/common/ifcs-dropdown/ifcs-dropdown.component.html
+++ b/frontend/src/app/shared/common/ifcs-dropdown/ifcs-dropdown.component.html
@@ -20,7 +20,7 @@
         <ng-template pTemplate="content">
             <ul>
                 <li *ngFor="let ifc of filteredIfcs()">
-                    <a [routerLink]="['/' + routeMap[ifc.id], resource?._id_]">{{ ifc.label }}</a>
+                    <a [routerLink]="getRouteCommands(ifc.id)">{{ ifc.label }}</a>
                 </li>
 
                 <li *ngFor="let link of processedExternalLinks">

--- a/frontend/src/app/shared/common/ifcs-dropdown/ifcs-dropdown.component.ts
+++ b/frontend/src/app/shared/common/ifcs-dropdown/ifcs-dropdown.component.ts
@@ -16,7 +16,7 @@ export type ExternalLink = {
 };
 
 /**
- * Create a dropdown that lists all links in a standard `_ifcs_ array on an Object.
+ * Create a dropdown that lists all links in a standard `_ifcs_` array on an Object.
  */
 @Component({
   selector: 'app-ifcs-dropdown',
@@ -44,7 +44,50 @@ export class IfcsDropdownComponent implements OnInit {
   }
 
   /**
-   * @returns only ifcs that don't point to current page.
+   * Returns the router commands for navigating to the given interface.
+   * SESSION/ONE-scope routes have no /:id segment in their config, so we navigate
+   * to the base path only. Regular-scope routes include resource._id_.
+   */
+  getRouteCommands(ifcId: string): (string | undefined)[] {
+    const basePath = this.routeMap[ifcId];
+    if (!basePath) return ['/'];
+    if (this.routeTakesId(basePath)) {
+      return ['/' + basePath, this.resource?._id_];
+    }
+    return ['/' + basePath];
+  }
+
+  /**
+   * Returns true if the given base route path expects an :id segment,
+   * i.e. the route is registered as `{base}/:id` in the router config.
+   * SESSION/ONE-scope interfaces have no such route and return false.
+   */
+  private routeTakesId(basePath: string): boolean {
+    const path = basePath.startsWith('/') ? basePath.slice(1) : basePath;
+    return this.findRouteWithId(this.router.config, path);
+  }
+
+  private findRouteWithId(
+    routes: { path?: string; children?: unknown[] }[],
+    targetBase: string,
+  ): boolean {
+    for (const route of routes) {
+      if (route.path === `${targetBase}/:id`) return true;
+      if (route.children) {
+        if (
+          this.findRouteWithId(
+            route.children as { path?: string; children?: unknown[] }[],
+            targetBase,
+          )
+        )
+          return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * @returns only ifcs that don't point to the current page.
    */
   filteredIfcs() {
     if (!this.resource || !this.resource._ifcs_) return [];
@@ -53,10 +96,9 @@ export class IfcsDropdownComponent implements OnInit {
       return [];
 
     return this.resource._ifcs_.filter((ifc) => {
-      return (
-        document.location.pathname !=
-        `${this.routeMap[ifc.id]}/${this.resource?._id_}`
-      );
+      const commands = this.getRouteCommands(ifc.id);
+      const targetPath = commands.filter(Boolean).join('/');
+      return document.location.pathname !== targetPath;
     });
   }
 
@@ -71,10 +113,7 @@ export class IfcsDropdownComponent implements OnInit {
   ): void {
     const ifcs = this.filteredIfcs();
     if (ifcs.length === 1 && this.processedExternalLinks.length === 0) {
-      this.router.navigate([
-        '/' + this.routeMap[ifcs[0].id],
-        this.resource?._id_,
-      ]);
+      this.router.navigate(this.getRouteCommands(ifcs[0].id));
       return;
     }
     dropdown.toggle(event);


### PR DESCRIPTION
## Problem

`filteredIfcs()` constructed every target path as `/{base}/{resource._id_}` for all interfaces, including SESSION and ONE-scope ones whose route config has no `/:id` segment. This produced non-existent URLs like `/clinics/Alice`.

The active-page filter also compared against the wrong path, so SESSION/ONE links were never filtered out.

## Fix

Add `getRouteCommands()` which inspects the Angular router config to determine whether a base route has a `/:id` variant. SESSION/ONE routes resolve to the base path only; regular-scope routes include the atom id as before.