### PR TITLE
fix: redirect /{session-route}/{id} URLs to the base path

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -2,17 +2,17 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { AppLayoutComponent } from './layout/app.layout.component';
 import { HomeComponent } from './layout/home/home.component';
-// import { ToolComponentDetailsComponent } from './tools/tool-component-details/tool-component-details.component';
-// import { ToolGalleryComponent } from './tools/tool-gallery/tool-gallery.component';
 import { NotFoundComponentComponent } from './layout/not-found-component/not-found-component.component';
 import { SignalsComponent } from './layout/signals/signals.component';
+import { SessionRouteRedirectGuard } from './shared/guards/session-route-redirect.guard';
 
 const routes: Routes = [
   { path: '', component: HomeComponent },
   { path: 'signals', component: SignalsComponent },
-  // { path: 'tools/', component: ToolGalleryComponent },
-  // { path: 'tools/:componentType/:componentName', component: ToolComponentDetailsComponent },
   { path: '404', component: NotFoundComponentComponent },
+  // Catch '{segment}/{id}' URLs where '{segment}' is a SESSION/ONE-scope route
+  // (no ':id' variant in the route config). Redirect to the base path instead of 404.
+  { path: ':segment/:id', canActivate: [SessionRouteRedirectGuard], component: NotFoundComponentComponent },
   { path: '**', component: NotFoundComponentComponent },
 ];
 

--- a/frontend/src/app/shared/guards/session-route-redirect.guard.ts
+++ b/frontend/src/app/shared/guards/session-route-redirect.guard.ts
@@ -1,0 +1,65 @@
+import { Inject, Injectable, Optional } from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  Router,
+  UrlTree,
+} from '@angular/router';
+import { InterfaceRouteMap, INTERFACE_ROUTE_MAPPING_TOKEN } from '../../config';
+
+/**
+ * Guard for the catch-all ':segment/:id' route.
+ *
+ * SESSION/ONE-scope interfaces have no /:id variant in their route config
+ * (e.g. 'clinics' is registered, but never 'clinics/:id'). When a URL like
+ * '/clinics/{uuid}' is produced (e.g. by an old routerLink or a directly typed
+ * URL), Angular finds no direct match and falls through to ':segment/:id'. This
+ * guard redirects it to the base path '/clinics' so the user lands on the
+ * correct page rather than a 404.
+ *
+ * OBJECT-scope routes (e.g. 'prototypecontext-editinterface/:id') match their
+ * own route directly and never reach this catch-all.
+ *
+ * Uses INTERFACE_ROUTE_MAPPING_TOKEN as the primary source of known paths, with
+ * a fallback to router.config for robustness. Both are available by the time
+ * this guard fires because all eagerly-loaded module routes are registered
+ * before the router processes its initial navigation.
+ */
+@Injectable({ providedIn: 'root' })
+export class SessionRouteRedirectGuard implements CanActivate {
+  private readonly knownBasePaths: Set<string>;
+
+  constructor(
+    private router: Router,
+    @Optional()
+    @Inject(INTERFACE_ROUTE_MAPPING_TOKEN)
+    routeMap: InterfaceRouteMap | null,
+  ) {
+    // Build the set of known base paths from the interface-to-route map.
+    // e.g. '/clinics' → 'clinics'. Object-scope routes like
+    // '/prototypecontext-editinterface' are included too, but those URLs arrive
+    // as 'prototypecontext-editinterface/:id' and match that route before this
+    // guard ever sees them.
+    this.knownBasePaths = routeMap
+      ? new Set(
+          Object.values(routeMap)
+            .filter((p): p is string => typeof p === 'string' && p.length > 0)
+            .map((p) => (p.startsWith('/') ? p.slice(1) : p)),
+        )
+      : new Set();
+  }
+
+  canActivate(route: ActivatedRouteSnapshot): boolean | UrlTree {
+    const segment = route.params['segment'];
+
+    // Primary: token-derived set. Fallback: router.config at call-time
+    // (all forChild routes are registered by now even if the set is empty).
+    const isKnown =
+      this.knownBasePaths.has(segment) ||
+      this.router.config.some((r) => r.path === segment);
+
+    return isKnown
+      ? this.router.createUrlTree(['/' + segment])
+      : this.router.createUrlTree(['/404']);
+  }
+}


### PR DESCRIPTION
## Problem

When a user navigated to a URL like `/clinics/some-id` where `clinics` is a SESSION-scope route (no `/:id` variant registered), the router fell through to the 404 page. This could happen via bookmarks, browser history, or copy-pasted links.

## Fix

Add `SessionRouteRedirectGuard`: a `canActivate` guard on a catch-all `/:segment/:id` route. If `:segment` matches a known base route in the router config, it redirects to that base path. Otherwise it lets the 404 stand.

Also removes dead commented-out tool-gallery route imports.